### PR TITLE
adding qubit attributes needed for flux routines fitting

### DIFF
--- a/iqm5q.yml
+++ b/iqm5q.yml
@@ -130,6 +130,10 @@ characterization:
             readout_frequency: 5_228_700_000
             resonator_polycoef_flux: []
             drive_frequency: 4095985280
+            anharmonicity: 0
+            Ec: 0
+            Ej: 0
+            g: 0            
             T1: 0.0
             T2: 0.0
             sweetspot: 0
@@ -144,6 +148,10 @@ characterization:
             readout_frequency: 4.9525e+9
             resonator_polycoef_flux: []
             drive_frequency: 4.25e+9
+            anharmonicity: 0
+            Ec: 0
+            Ej: 0
+            g: 0            
             T1: 0.0
             T2: 0.0
             sweetspot: 0
@@ -154,6 +162,10 @@ characterization:
             readout_frequency: 6.109e+9
             resonator_polycoef_flux: []
             drive_frequency: 4342116873
+            anharmonicity: 0
+            Ec: 0
+            Ej: 0
+            g: 0            
             T1: 0.0
             T2: 0.0
             sweetspot: -0.1745
@@ -168,6 +180,10 @@ characterization:
             readout_frequency: 5.8060e+9
             resonator_polycoef_flux: []
             drive_frequency: 4130512577
+            anharmonicity: 0
+            Ec: 0
+            Ej: 0
+            g: 0            
             T1: 0.0
             T2: 0.0
             sweetspot: 0.0
@@ -182,6 +198,10 @@ characterization:
             readout_frequency: 5.5240e+9
             resonator_polycoef_flux: []
             drive_frequency: 4.1017e+9
+            anharmonicity: 0
+            Ec: 0
+            Ej: 0
+            g: 0            
             T1: 0.0
             T2: 0.0
             sweetspot: 0

--- a/iqm5q.yml
+++ b/iqm5q.yml
@@ -133,7 +133,7 @@ characterization:
             anharmonicity: 0
             Ec: 0
             Ej: 0
-            g: 0            
+            g: 0
             T1: 0.0
             T2: 0.0
             sweetspot: 0
@@ -151,7 +151,7 @@ characterization:
             anharmonicity: 0
             Ec: 0
             Ej: 0
-            g: 0            
+            g: 0
             T1: 0.0
             T2: 0.0
             sweetspot: 0
@@ -165,7 +165,7 @@ characterization:
             anharmonicity: 0
             Ec: 0
             Ej: 0
-            g: 0            
+            g: 0
             T1: 0.0
             T2: 0.0
             sweetspot: -0.1745
@@ -183,7 +183,7 @@ characterization:
             anharmonicity: 0
             Ec: 0
             Ej: 0
-            g: 0            
+            g: 0
             T1: 0.0
             T2: 0.0
             sweetspot: 0.0
@@ -201,7 +201,7 @@ characterization:
             anharmonicity: 0
             Ec: 0
             Ej: 0
-            g: 0            
+            g: 0
             T1: 0.0
             T2: 0.0
             sweetspot: 0

--- a/qw25q.yml
+++ b/qw25q.yml
@@ -414,6 +414,10 @@ characterization:
         A1:
             readout_frequency: 6886009383
             drive_frequency: 5.06217e+9
+            anharmonicity: 0
+            Ec: 0
+            Ej: 0
+            g: 0
             T1: 0.0
             T2: 0.0
             sweetspot: 0.0
@@ -429,6 +433,10 @@ characterization:
         A2:
             readout_frequency: 7267518645
             drive_frequency: 5.8513e+9
+            anharmonicity: 0
+            Ec: 0
+            Ej: 0
+            g: 0            
             T1: 0.0
             T2: 0.0
             sweetspot: 0.05
@@ -444,6 +452,10 @@ characterization:
         A3:
             readout_frequency: 7.5213366e+9
             drive_frequency: 5.991311e+9
+            anharmonicity: 0
+            Ec: 0
+            Ej: 0
+            g: 0            
             T1: 0.0
             T2: 0.0
             sweetspot: 0.0
@@ -459,6 +471,10 @@ characterization:
         A4:
             readout_frequency: 7119206723
             drive_frequency: 5.239805e+9
+            anharmonicity: 0
+            Ec: 0
+            Ej: 0
+            g: 0            
             T1: 0.0
             T2: 0.0
             sweetspot: 0.0
@@ -474,6 +490,10 @@ characterization:
         A5:
             readout_frequency: 7.692063E+09
             drive_frequency: 6081000000
+            anharmonicity: 0
+            Ec: 0
+            Ej: 0
+            g: 0            
             T1: 0.0
             T2: 0.0
             sweetspot: 0.0
@@ -489,6 +509,10 @@ characterization:
         A6:
             readout_frequency: 7942098387
             drive_frequency: 6.860000E+09
+            anharmonicity: 0
+            Ec: 0
+            Ej: 0
+            g: 0            
             T1: 0.0
             T2: 0.0
             sweetspot: 0.0
@@ -504,6 +528,10 @@ characterization:
         B1:
             readout_frequency: 6.927829E+09
             drive_frequency: 5.057380E+09
+            anharmonicity: 0
+            Ec: 0
+            Ej: 0
+            g: 0            
             T1: 0.0
             T2: 0.0
             sweetspot: 0.0
@@ -519,6 +547,10 @@ characterization:
         B2:
             readout_frequency: 7.138028E+09
             drive_frequency: 6.017959E+09
+            anharmonicity: 0
+            Ec: 0
+            Ej: 0
+            g: 0            
             T1: 0.0
             T2: 0.0
             sweetspot: 0.0
@@ -534,6 +566,10 @@ characterization:
         B3:
             readout_frequency: 7.343333E+09
             drive_frequency: 6.058000E+09
+            anharmonicity: 0
+            Ec: 0
+            Ej: 0
+            g: 0            
             T1: 0.0
             T2: 0.0
             sweetspot: 0.0
@@ -549,6 +585,10 @@ characterization:
         B4:
             readout_frequency: 7.748361E+09
             drive_frequency: 6.120616E+09
+            anharmonicity: 0
+            Ec: 0
+            Ej: 0
+            g: 0            
             T1: 0.0
             T2: 0.0
             sweetspot: 0.0
@@ -564,6 +604,10 @@ characterization:
         B5:
             readout_frequency: 7.599758E+09
             drive_frequency: 6.101000E+09
+            anharmonicity: 0
+            Ec: 0
+            Ej: 0
+            g: 0            
             T1: 0.0
             T2: 0.0
             sweetspot: 0.0
@@ -579,6 +623,10 @@ characterization:
         C1:
             readout_frequency: 7.061090E+09
             drive_frequency: 5.405000E+09
+            anharmonicity: 0
+            Ec: 0
+            Ej: 0
+            g: 0            
             T1: 0.0
             T2: 0.0
             sweetspot: 0.0
@@ -594,6 +642,10 @@ characterization:
         C2:
             readout_frequency: 7.460670E+09
             drive_frequency: 6.084000E+09
+            anharmonicity: 0
+            Ec: 0
+            Ej: 0
+            g: 0            
             T1: 0.0
             T2: 0.0
             sweetspot: 0.0
@@ -609,6 +661,10 @@ characterization:
         C3:
             readout_frequency: 7.627060E+09
             drive_frequency: 5.803000E+09
+            anharmonicity: 0
+            Ec: 0
+            Ej: 0
+            g: 0            
             T1: 0.0
             T2: 0.0
             sweetspot: 0.0
@@ -624,6 +680,10 @@ characterization:
         C4:
             readout_frequency: 7.220770E+09
             drive_frequency: 5.388000E+09
+            anharmonicity: 0
+            Ec: 0
+            Ej: 0
+            g: 0            
             T1: 0.0
             T2: 0.0
             sweetspot: 0.0
@@ -639,6 +699,10 @@ characterization:
         C5:
             readout_frequency: 7.830770E+09
             drive_frequency: 5.822600E+09
+            anharmonicity: 0
+            Ec: 0
+            Ej: 0
+            g: 0            
             T1: 0.0
             T2: 0.0
             sweetspot: 0.0
@@ -654,6 +718,10 @@ characterization:
         D1:
             readout_frequency: 6.952000E+09
             drive_frequency: 4.967000E+09
+            anharmonicity: 0
+            Ec: 0
+            Ej: 0
+            g: 0            
             T1: 0.0
             T2: 0.0
             sweetspot: 0.0
@@ -669,6 +737,10 @@ characterization:
         D2:
             readout_frequency: 7.111110E+09
             drive_frequency: 5.746000E+09
+            anharmonicity: 0
+            Ec: 0
+            Ej: 0
+            g: 0            
             T1: 0.0
             T2: 0.0
             sweetspot: 0.0
@@ -684,6 +756,10 @@ characterization:
         D3:
             readout_frequency: 7.342070E+09
             drive_frequency: 6.036000E+09
+            anharmonicity: 0
+            Ec: 0
+            Ej: 0
+            g: 0            
             T1: 0.0
             T2: 0.0
             sweetspot: 0.0
@@ -698,6 +774,10 @@ characterization:
         D4:
             readout_frequency: 7.800000E+09
             drive_frequency: 6.552000E+09
+            anharmonicity: 0
+            Ec: 0
+            Ej: 0
+            g: 0            
             T1: 0.0
             T2: 0.0
             sweetspot: 0.0
@@ -712,6 +792,10 @@ characterization:
         D5:
             readout_frequency: 7.459960E+09
             drive_frequency: 5.983000E+09
+            anharmonicity: 0
+            Ec: 0
+            Ej: 0
+            g: 0            
             T1: 0.0
             T2: 0.0
             sweetspot: 0.0

--- a/qw25q.yml
+++ b/qw25q.yml
@@ -436,7 +436,7 @@ characterization:
             anharmonicity: 0
             Ec: 0
             Ej: 0
-            g: 0            
+            g: 0
             T1: 0.0
             T2: 0.0
             sweetspot: 0.05
@@ -455,7 +455,7 @@ characterization:
             anharmonicity: 0
             Ec: 0
             Ej: 0
-            g: 0            
+            g: 0
             T1: 0.0
             T2: 0.0
             sweetspot: 0.0
@@ -474,7 +474,7 @@ characterization:
             anharmonicity: 0
             Ec: 0
             Ej: 0
-            g: 0            
+            g: 0
             T1: 0.0
             T2: 0.0
             sweetspot: 0.0
@@ -493,7 +493,7 @@ characterization:
             anharmonicity: 0
             Ec: 0
             Ej: 0
-            g: 0            
+            g: 0
             T1: 0.0
             T2: 0.0
             sweetspot: 0.0
@@ -512,7 +512,7 @@ characterization:
             anharmonicity: 0
             Ec: 0
             Ej: 0
-            g: 0            
+            g: 0
             T1: 0.0
             T2: 0.0
             sweetspot: 0.0
@@ -531,7 +531,7 @@ characterization:
             anharmonicity: 0
             Ec: 0
             Ej: 0
-            g: 0            
+            g: 0
             T1: 0.0
             T2: 0.0
             sweetspot: 0.0
@@ -550,7 +550,7 @@ characterization:
             anharmonicity: 0
             Ec: 0
             Ej: 0
-            g: 0            
+            g: 0
             T1: 0.0
             T2: 0.0
             sweetspot: 0.0
@@ -569,7 +569,7 @@ characterization:
             anharmonicity: 0
             Ec: 0
             Ej: 0
-            g: 0            
+            g: 0
             T1: 0.0
             T2: 0.0
             sweetspot: 0.0
@@ -588,7 +588,7 @@ characterization:
             anharmonicity: 0
             Ec: 0
             Ej: 0
-            g: 0            
+            g: 0
             T1: 0.0
             T2: 0.0
             sweetspot: 0.0
@@ -607,7 +607,7 @@ characterization:
             anharmonicity: 0
             Ec: 0
             Ej: 0
-            g: 0            
+            g: 0
             T1: 0.0
             T2: 0.0
             sweetspot: 0.0
@@ -626,7 +626,7 @@ characterization:
             anharmonicity: 0
             Ec: 0
             Ej: 0
-            g: 0            
+            g: 0
             T1: 0.0
             T2: 0.0
             sweetspot: 0.0
@@ -645,7 +645,7 @@ characterization:
             anharmonicity: 0
             Ec: 0
             Ej: 0
-            g: 0            
+            g: 0
             T1: 0.0
             T2: 0.0
             sweetspot: 0.0
@@ -664,7 +664,7 @@ characterization:
             anharmonicity: 0
             Ec: 0
             Ej: 0
-            g: 0            
+            g: 0
             T1: 0.0
             T2: 0.0
             sweetspot: 0.0
@@ -683,7 +683,7 @@ characterization:
             anharmonicity: 0
             Ec: 0
             Ej: 0
-            g: 0            
+            g: 0
             T1: 0.0
             T2: 0.0
             sweetspot: 0.0
@@ -702,7 +702,7 @@ characterization:
             anharmonicity: 0
             Ec: 0
             Ej: 0
-            g: 0            
+            g: 0
             T1: 0.0
             T2: 0.0
             sweetspot: 0.0
@@ -721,7 +721,7 @@ characterization:
             anharmonicity: 0
             Ec: 0
             Ej: 0
-            g: 0            
+            g: 0
             T1: 0.0
             T2: 0.0
             sweetspot: 0.0
@@ -740,7 +740,7 @@ characterization:
             anharmonicity: 0
             Ec: 0
             Ej: 0
-            g: 0            
+            g: 0
             T1: 0.0
             T2: 0.0
             sweetspot: 0.0
@@ -759,7 +759,7 @@ characterization:
             anharmonicity: 0
             Ec: 0
             Ej: 0
-            g: 0            
+            g: 0
             T1: 0.0
             T2: 0.0
             sweetspot: 0.0
@@ -777,7 +777,7 @@ characterization:
             anharmonicity: 0
             Ec: 0
             Ej: 0
-            g: 0            
+            g: 0
             T1: 0.0
             T2: 0.0
             sweetspot: 0.0
@@ -795,7 +795,7 @@ characterization:
             anharmonicity: 0
             Ec: 0
             Ej: 0
-            g: 0            
+            g: 0
             T1: 0.0
             T2: 0.0
             sweetspot: 0.0

--- a/qw5q_gold.yml
+++ b/qw5q_gold.yml
@@ -405,7 +405,10 @@ characterization:
         0:
             readout_frequency: 7_212_362_551
             drive_frequency: 5_045_070_000
-            # anharmonicity: 291_451_184
+            anharmonicity: 291_463_266
+            Ec: 270_000_000
+            Ej: 11_400_000_000
+            g: 107_000_000
             T1: 5_857
             T2: 0
             state0_voltage: 0.0
@@ -416,7 +419,10 @@ characterization:
         1:
             readout_frequency: 7_453_149_599
             drive_frequency: 4_852_280_321
-            # anharmonicity: 291_965_010
+            anharmonicity: 292_584_018
+            Ec: 270_000_000
+            Ej: 11_400_000_000
+            g: 114_000_000
             T1: 1_253
             T2: 0
             state0_voltage: 0.0
@@ -427,7 +433,10 @@ characterization:
         2:
             readout_frequency: 7_655_110_446
             drive_frequency: 5_794_176_000
-            # anharmonicity: 275_392_460
+            anharmonicity: 276_187_576
+            Ec: 270_000_000
+            Ej: 16_000_000_000
+            g: 83_600_000
             T1: 4_563
             T2: 0
             state0_voltage: 0.0
@@ -438,7 +447,10 @@ characterization:
         3:
             readout_frequency: 7_803_377_426
             drive_frequency: 6_760_050_000
-            # anharmonicity: 261_797_410
+            anharmonicity: 262_310_994
+            Ec: 270_000_000
+            Ej: 21_200_000_000
+            g: 54_300_000
             T1: 4_232
             T2: 0
             state0_voltage: 0.0
@@ -449,7 +461,10 @@ characterization:
         4:
             readout_frequency: 8_058_739_833
             drive_frequency: 6_585_145_857
-            # anharmonicity: 253_106_666
+            anharmonicity: 261_390_626
+            Ec: 270_000_000
+            Ej: 21_200_000_000
+            g: 62_700_000
             T1: 492
             T2: 0
             state0_voltage: 0.0
@@ -460,7 +475,10 @@ characterization:
         5:
             readout_frequency: 7_118_627_416
             drive_frequency: 4_700_000_000
-            # anharmonicity: 300_000_000
+            anharmonicity: 300_000_000
+            Ec: 270_000_000
+            Ej: 11_400_000_000
+            g: 77_600_000
             T1: 0
             T2: 0
             state0_voltage: 0.0

--- a/tii1q_b1.yml
+++ b/tii1q_b1.yml
@@ -19,7 +19,7 @@ characterization:
             anharmonicity: 0
             Ec: 0
             Ej: 0
-            g: 0            
+            g: 0
             pi_pulse_amplitude: 0.704
             T1: 11543.451107305236
             T2: 4316.1384768762455

--- a/tii1q_b1.yml
+++ b/tii1q_b1.yml
@@ -16,6 +16,10 @@ characterization:
         0:
             readout_frequency: 7369620478
             drive_frequency: 5509784692
+            anharmonicity: 0
+            Ec: 0
+            Ej: 0
+            g: 0            
             pi_pulse_amplitude: 0.704
             T1: 11543.451107305236
             T2: 4316.1384768762455

--- a/tii_zcu111.yml
+++ b/tii_zcu111.yml
@@ -94,7 +94,7 @@ characterization:   #TODO No characterization yet
             anharmonicity: 0
             Ec: 0
             Ej: 0
-            g: 0            
+            g: 0
             T1: 0.0
             T2: 0.0
             sweetspot: 0.28
@@ -106,7 +106,7 @@ characterization:   #TODO No characterization yet
             anharmonicity: 0
             Ec: 0
             Ej: 0
-            g: 0            
+            g: 0
             T1: 0.0
             T2: 0.0
             sweetspot: -0.33
@@ -118,7 +118,7 @@ characterization:   #TODO No characterization yet
             anharmonicity: 0
             Ec: 0
             Ej: 0
-            g: 0            
+            g: 0
             T1: 0.0
             T2: 0.0
             sweetspot: -0.08

--- a/tii_zcu111.yml
+++ b/tii_zcu111.yml
@@ -91,6 +91,10 @@ characterization:   #TODO No characterization yet
         0:
             readout_frequency: 7_111_290_000
             drive_frequency: 5_722_860_285
+            anharmonicity: 0
+            Ec: 0
+            Ej: 0
+            g: 0            
             T1: 0.0
             T2: 0.0
             sweetspot: 0.28
@@ -99,6 +103,10 @@ characterization:   #TODO No characterization yet
         1:
             readout_frequency: 7_345_317_000
             drive_frequency: 6_085_931_000
+            anharmonicity: 0
+            Ec: 0
+            Ej: 0
+            g: 0            
             T1: 0.0
             T2: 0.0
             sweetspot: -0.33
@@ -107,6 +115,10 @@ characterization:   #TODO No characterization yet
         2:
             readout_frequency: 7_458_000_000
             drive_frequency: 0.0
+            anharmonicity: 0
+            Ec: 0
+            Ej: 0
+            g: 0            
             T1: 0.0
             T2: 0.0
             sweetspot: -0.08


### PR DESCRIPTION
This PR adds the Ec, Ej, g and assigment fidelity to the qubit runcards. These attributes are needed in qibocal for flux flux routines fitting (david/flux_routines_fitting).

Assigment fidelity needed for a webapp tool that I have implemented that shows the qpus/qubits status and latest characterization

@scarrazza could we merge this PR as soon as possible. Tests in qibocal PR 437 (https://github.com/qiboteam/qibocal/pull/437) are not passing because we need these attributes.