### PR TITLE
David/qw5q latest characterization

### DIFF
--- a/qw5q_gold.py
+++ b/qw5q_gold.py
@@ -1,10 +1,326 @@
 import pathlib
+import networkx as nx
+import yaml
 
+from qibolab.platform import Platform
+from qibolab.instruments.qblox.controller import QbloxController
+from qibolab.instruments.qblox.cluster import Cluster
+from qibolab.instruments.qblox.cluster_qrm_rf import ClusterQRM_RF
+from qibolab.instruments.qblox.cluster_qcm_rf import ClusterQCM_RF
+from qibolab.instruments.qblox.cluster_qcm_bb import ClusterQCM_BB
+from qibolab.instruments.rohde_schwarz import SGS100A
+from qibolab.channels import Channel, ChannelMap
+
+NAME = "qblox"
+ADDRESS = "192.168.0.6"
+TIME_OF_FLIGHT = 500
 RUNCARD = pathlib.Path(__file__).parent / "qw5q_gold.yml"
+
+instruments_settings = {
+
+    'cluster': {
+        'settings': {
+            'reference_clock_source': 'internal'
+            }
+        }, 
+    'qrm_rf_a': {
+        'settings': {
+            'ports': {
+                'o1': {
+                    'channel': 'L3-25_a', 
+                    'attenuation': 38, 
+                    'lo_enabled': True, 
+                    'lo_frequency': 7_255_000_000, 
+                    'gain': 0.6
+                    }, 
+                'i1': {
+                    'channel': 'L2-5_a', 
+                    'acquisition_hold_off': 500, 
+                    'acquisition_duration': 900
+                    }
+                }, 
+                'classification_parameters': {
+                    0: {'rotation_angle':  99.758, 'threshold': 0.003933}, 
+                    1: {'rotation_angle': 146.297, 'threshold': 0.003488}
+                }
+            }
+        }, 
+    'qrm_rf_b': {
+        'settings': {
+            'ports': {
+                'o1': {
+                    'channel': 'L3-25_b', 
+                    'attenuation': 32, 
+                    'lo_enabled': True, 
+                    'lo_frequency': 7_850_000_000, 
+                    'gain': 0.6
+                    }, 
+                'i1': {
+                    'channel': 'L2-5_b', 
+                    'acquisition_hold_off': 500, 
+                    'acquisition_duration': 900
+                    }
+                }, 
+                'classification_parameters': {
+                    2: {'rotation_angle': 97.821, 'threshold': 0.002904}, 
+                    3: {'rotation_angle': 91.209, 'threshold': 0.004318}, 
+                    4: {'rotation_angle': 7.997, 'threshold': 0.002323}
+                }
+            }
+        }, 
+    'qcm_rf0': {
+        'settings': {
+            'ports': {
+                'o1': {
+                    'channel': 'L3-15', 
+                    'attenuation': 20, 
+                    'lo_enabled': True, 
+                    'lo_frequency': 5_250_304_836, 
+                    'gain': 0.470}
+                }
+            }
+        }, 
+    'qcm_rf1': {
+        'settings': {
+            'ports': {
+                'o1': {
+                    'channel': 'L3-11', 
+                    'attenuation': 20, 
+                    'lo_enabled': True, 
+                    'lo_frequency': 5_052_833_073, 
+                    'gain': 0.570
+                    }, 
+                'o2': {
+                    'channel': 'L3-12', 
+                    'attenuation': 20, 
+                    'lo_enabled': True, 
+                    'lo_frequency': 5_995_371_914, 
+                    'gain': 0.655
+                    }
+                }
+            }
+        }, 
+    'qcm_rf2': {
+        'settings': {
+            'ports': {
+                'o1': {
+                    'channel': 'L3-13', 
+                    'attenuation': 20, 
+                    'lo_enabled': True, 
+                    'lo_frequency': 6_961_018_001, 
+                    'gain': 0.550
+                    }, 
+                'o2': {
+                    'channel': 'L3-14', 
+                    'attenuation': 20, 
+                    'lo_enabled': True, 
+                    'lo_frequency': 6_786_543_060, 
+                    'gain': 0.596
+                    }
+                }
+            }
+        }, 
+    'qcm_bb0': {
+        'settings': {
+            'ports': {
+                'o1': {
+                    'channel': 'L4-5', 
+                    'gain': 0.5, 
+                    'offset': 0.5507, 
+                    'qubit': 0
+                    }
+                }
+            }
+        }, 
+    'qcm_bb1': {
+        'settings': {
+            'ports': {
+                'o1': {
+                    'channel': 'L4-1', 
+                    'gain': 0.5, 
+                    'offset': 0.2227, 
+                    'qubit': 1
+                    }, 
+                'o2': {
+                    'channel': 'L4-2', 
+                    'gain': 0.5, 
+                    'offset': -0.3780, 
+                    'qubit': 2
+                    }, 
+                'o3': {
+                    'channel': 'L4-3', 
+                    'gain': 0.5, 
+                    'offset': -0.8899, 
+                    'qubit': 3
+                    }, 
+                'o4': {
+                    'channel': 'L4-4', 
+                    'gain': 0.5, 
+                    'offset': 0.5890, 
+                    'qubit': 4
+                    }
+                }
+            }
+        }, 
+    'twpa_pump': {
+        'settings': {
+            'frequency': 6_535_900_000, 
+            'power': 4
+            }
+        }
+    }
 
 
 def create(runcard=RUNCARD):
-    """QuantWare 5q-chip controlled using qblox cluster rf."""
-    from qibolab.platforms.multiqubit import MultiqubitPlatform
+    """QuantWare 5q-chip controlled using qblox cluster.
 
-    return MultiqubitPlatform("qw5q_gold", runcard)
+    Args:
+        runcard (str): Path to the runcard file.
+    """
+
+    def instantiate_module(modules, cls, name, address, settings):
+        module_settings = settings[name]["settings"]
+        modules[name] = cls(name=name, address=address, settings=module_settings)
+        return modules[name]
+    
+    modules = {}
+
+    cluster  = Cluster(name="cluster", address="192.168.0.6", settings=instruments_settings["cluster"]["settings"])
+    
+    qrm_rf_a = instantiate_module(modules, ClusterQRM_RF, "qrm_rf_a", "192.168.0.6:10", instruments_settings) # qubits q0, q1, q5
+    qrm_rf_b = instantiate_module(modules, ClusterQRM_RF, "qrm_rf_b", "192.168.0.6:12", instruments_settings) # qubits q2, q3, q4
+    
+    qcm_rf0  = instantiate_module(modules, ClusterQCM_RF, "qcm_rf0", "192.168.0.6:8", instruments_settings) # qubit q0
+    qcm_rf1  = instantiate_module(modules, ClusterQCM_RF, "qcm_rf1", "192.168.0.6:3", instruments_settings) # qubits q1, q2
+    qcm_rf2  = instantiate_module(modules, ClusterQCM_RF, "qcm_rf2", "192.168.0.6:4", instruments_settings) # qubits q3, q4
+    
+    qcm_bb0  = instantiate_module(modules, ClusterQCM_BB, "qcm_bb0", "192.168.0.6:5", instruments_settings) # qubit q0
+    qcm_bb1  = instantiate_module(modules, ClusterQCM_BB, "qcm_bb1", "192.168.0.6:2", instruments_settings) # qubits q1, q2, q3, q4
+
+    
+    # DEBUG: debug folder = report folder
+    # import os
+    # folder = os.path.dirname(runcard) + "/debug/"
+    # if not os.path.exists(folder):
+    #     os.makedirs(folder)
+    # for name in modules:
+    #     modules[name]._debug_folder = folder
+
+
+    controller = QbloxController("qblox_controller", cluster, modules)
+
+    twpa_pump = SGS100A(name="twpa_pump", address="192.168.0.37")
+    twpa_pump.frequency = instruments_settings["twpa_pump"]["settings"]["frequency"]
+    twpa_pump.power = instruments_settings["twpa_pump"]["settings"]["power"]
+    
+    instruments = [controller, twpa_pump]
+    
+    # Create channel objects
+    channels = {}
+    # readout
+    channels["L3-25_a"] = Channel(name="L3-25_a", port=qrm_rf_a.ports["o1"])
+    channels["L3-25_b"] = Channel(name="L3-25_b", port=qrm_rf_b.ports["o1"])
+
+    # feedback
+    channels["L2-5_a"] = Channel(name="L2-5_a", port=qrm_rf_a.ports["i1"])
+    channels["L2-5_b"] = Channel(name="L2-5_b", port=qrm_rf_b.ports["i1"])
+
+    # drive
+    channels["L3-15"] = Channel(name="L3-15", port=qcm_rf0.ports["o1"])
+    channels["L3-11"] = Channel(name="L3-11", port=qcm_rf1.ports["o1"])
+    channels["L3-12"] = Channel(name="L3-12", port=qcm_rf1.ports["o2"])
+    channels["L3-13"] = Channel(name="L3-13", port=qcm_rf2.ports["o1"])
+    channels["L3-14"] = Channel(name="L3-14", port=qcm_rf2.ports["o2"])
+
+    # flux
+    channels["L4-5"] = Channel(name="L4-5", port=qcm_bb0.ports["o1"])
+    channels["L4-1"] = Channel(name="L4-1", port=qcm_bb1.ports["o1"])
+    channels["L4-2"] = Channel(name="L4-2", port=qcm_bb1.ports["o2"])
+    channels["L4-3"] = Channel(name="L4-3", port=qcm_bb1.ports["o3"])
+    channels["L4-4"] = Channel(name="L4-4", port=qcm_bb1.ports["o4"])
+
+    # TWPA
+    channels["L4-26"] = Channel(name="L4-4", port=None)
+
+    platform = Platform(name="qw5q_gold_qblox", runcard=runcard, instruments=instruments, channels=channels)
+
+    # assign channels to qubits
+    qubits = platform.qubits
+    for q in [0, 1, 5]:
+        qubits[q].readout = channels["L3-25_a"]
+        qubits[q].feedback = channels["L2-5_a"]
+        qubits[q].twpa = channels["L4-26"]
+    for q in [2, 3, 4]:
+        qubits[q].readout = channels["L3-25_b"]
+        qubits[q].feedback = channels["L2-5_b"]
+        qubits[q].twpa = channels["L4-26"]
+
+    qubits[0].drive = channels["L3-15"]
+    qubits[0].flux = channels["L4-5"]
+    channels["L4-5"].qubit = qubits[0]
+    for q in range(1, 5):
+        qubits[q].drive = channels[f"L3-{10 + q}"]
+        qubits[q].flux = channels[f"L4-{q}"]
+        channels[f"L4-{q}"].qubit = qubits[q]
+
+    # set maximum allowed bias
+    for q in range(5):
+        platform.qubits[q].flux.max_bias = 2.5
+    # Platfom topology
+    
+    Q = [f"q{i}" for i in range(5)]
+    chip = nx.Graph()
+    chip.add_nodes_from(Q)
+    graph_list = [
+        (Q[0], Q[2]),
+        (Q[1], Q[2]),
+        (Q[3], Q[2]),
+        (Q[4], Q[2]),
+    ]
+    chip.add_edges_from(graph_list)
+    platform.topology = chip
+
+    return platform
+
+
+
+
+# Drive:
+# L3-15:mod8-o1 q0
+# L3-11:mod3-o1 q1
+# L3-12:mod3-o2 q2
+# L3-13:mod4-o1 q3
+# L3-14:mod4-o2 q4
+
+
+# Flux:
+# L4-5:mod5-o1 q0
+# L4-1:mod2-o1 q1
+# L4-2:mod2-o2 q2
+# L4-3:mod2-o3 q3
+# L4-4:mod2-o4 q4
+
+
+# Readout out:
+# L3-25:mod12 and mod10 (out)
+# L2-25:mod12 and mod10 (in)
+
+# Cluster IP:
+# 192.168.0.6
+
+
+# # no bias line, using qblox offset from qcm_bbc
+# channels: [
+#   'L2-5a','L2-5b', 'L3-25a', 'L3-25b', #RO channels: Ro lines L2-5 and L3-25 splitted
+#   'L3-15', 'L3-11', 'L3-12', 'L3-13', 'L3-14', 'L3-16', # Drive channels q0, q1, q2, q3, q4 | not used ports label: L3-16
+#   'L4-5', 'L4-1', 'L4-2', 'L4-3', 'L4-4', 'L4-6', 'L4-7', 'L4-8', # Flux channels q0, q1, q2, q3, q4 | not used labels: 'L4-6', 'L4-7', 'L4-8'
+# ]
+
+# # [ReadOut, QubitDrive, QubitFlux, QubitBias]
+# qubit_channel_map:
+#     0:   [L3-25a, L3-15, L4-5, null] #q0
+#     1:   [L3-25a, L3-11, L4-1, null] #q1
+#     2:   [L3-25b, L3-12, L4-2, null] #q2
+#     3:   [L3-25b, L3-13, L4-3, null] #q3
+#     4:   [L3-25b, L3-14, L4-4, null] #q4
+#     5:   [L3-25a,  null, null, null] #q5 witness

--- a/qw5q_gold.yml
+++ b/qw5q_gold.yml
@@ -12,6 +12,30 @@ resonator_type: 2D
 
 topology: [[0, 2], [1, 2], [2, 3], [2, 4]]
 
+# Drive:
+# L3-15:mod8-o1 q0
+# L3-11:mod3-o1 q1
+# L3-12:mod3-o2 q2
+# L3-13:mod4-o1 q3
+# L3-14:mod4-o2 q4
+
+
+# Flux:
+# L4-5:mod5-o1 q0
+# L4-1:mod2-o1 q1
+# L4-2:mod2-o2 q2
+# L4-3:mod2-o3 q3
+# L4-4:mod2-o4 q4
+
+
+# Readout out:
+# L3-25:mod12 and mod10 (out)
+# L2-25:mod12 and mod10 (in)
+
+# Cluster IP:
+# 192.168.0.6
+
+
 # no bias line, using qblox offset from qcm_bbc
 channels: [
   'L2-5a','L2-5b', 'L3-25a', 'L3-25b', #RO channels: Ro lines L2-5 and L3-25 splitted
@@ -45,16 +69,15 @@ instruments:
         settings:
             ports:
                 o1:
-                    attenuation                 : 38 # should be multiple of 2
+                    channel                     : L3-25a
+                    attenuation                 : 38                        # should be multiple of 2
                     lo_enabled                  : true
-                    lo_frequency                : 7_255_000_000                    # (Hz) from 2e9 to 18e9
-                    gain                        : 0.6                              # for path0 and path1 -1.0<=v<=1.0
-                    hardware_mod_en             : true
+                    lo_frequency                : 7_255_000_000             # (Hz) from 2e9 to 18e9
+                    gain                        : 0.6                       # for path0 and path1 -1.0<=v<=1.0
                 i1:
-                    hardware_demod_en           : true
-
-            acquisition_hold_off        : 500
-            acquisition_duration        : 900
+                    channel                     : L2-5a
+                    acquisition_hold_off        : 500                       # must be multiple of 4
+                    acquisition_duration        : 900
 
             classification_parameters:
                 0:  # qubit id
@@ -64,11 +87,6 @@ instruments:
                     rotation_angle              : 37.712                   # in degrees 0.0<=v<=360.0
                     threshold                   : 0.002625                  # in V
 
-
-            channel_port_map:   # Refrigerator Channel : Instrument port
-                'L3-25a' : o1    # IQ Port = out0 & out1
-                'L2-5a' : i1     # Labeled but not used
-
     qrm_rf2: # ReadOut module 12: controlling qubits q2, q3, q4
         lib: qblox
         class: ClusterQRM_RF
@@ -77,16 +95,15 @@ instruments:
         settings:
             ports:
                 o1:
-                    attenuation                 : 32 # should be multiple of 2
+                    channel                     : L3-25b
+                    attenuation                 : 32                        # should be multiple of 2
                     lo_enabled                  : true
-                    lo_frequency                : 7_850_000_000                   # (Hz) from 2e9 to 18e9
-                    gain                        : 0.6                              # for path0 and path1 -1.0<=v<=1.0
-                    hardware_mod_en             : true
+                    lo_frequency                : 7_850_000_000             # (Hz) from 2e9 to 18e9
+                    gain                        : 0.6                       # for path0 and path1 -1.0<=v<=1.0
                 i1:
-                    hardware_demod_en           : true
-
-            acquisition_hold_off        : 500
-            acquisition_duration        : 900
+                    channel                     : L2-5b
+                    acquisition_hold_off        : 500
+                    acquisition_duration        : 900
 
             classification_parameters:
                 2:  # qubit id
@@ -99,10 +116,6 @@ instruments:
                     rotation_angle              : 216.618                   # in degrees 0.0<=v<=360.0
                     threshold                   : 0.001338                  # in V
 
-            channel_port_map:   # Refrigerator Channel : Instrument port
-                'L3-25b' : o1    # IQ Port = out0 & out1
-                'L2-5b' : i1     # Labeled but not used
-
     qcm_rf1:
         lib: qblox
         class: ClusterQCM_RF
@@ -111,21 +124,11 @@ instruments:
         settings:
             ports:
                 o1: # qubit q0
-                    attenuation                  : 20 # (dB) # should be multiple of 2
-                    lo_enabled                   : true
-                    lo_frequency                 : 5_250_304_836 # (Hz) from 2e9 to 18e9
-                    gain                         : 0.470 # for path0 and path1 -1.0<=v<=1.0
-                    hardware_mod_en              : true
-                o2: # not used
-                    attenuation                  : 0 # (dB)
-                    lo_enabled                   : false
-                    lo_frequency                 : 2_000_000_000 # (Hz) from 2e9 to 18e9
-                    gain                         : 0 # for path0 and path1 -1.0<=v<=1.0
-                    hardware_mod_en              : true
-
-            channel_port_map:
-                'L3-15': o1 # q0
-                'L3-16': o2 # not used port
+                    channel             : L3-15
+                    attenuation         : 20                        # (dB) # should be multiple of 2
+                    lo_enabled          : true
+                    lo_frequency        : 5_250_304_836             # (Hz) from 2e9 to 18e9
+                    gain                : 0.470                     # for path0 and path1 -1.0<=v<=1.0
 
     qcm_rf2:
         lib: qblox
@@ -135,21 +138,17 @@ instruments:
         settings:
             ports:
                 o1: # qubit q1
-                    attenuation                  : 20 # (dB)
-                    lo_enabled                   : true
-                    lo_frequency                 : 5_052_833_073 # (Hz) from 2e9 to 18e9
-                    gain                         : 0.570 # for path0 and path1 -1.0<=v<=1.0
-                    hardware_mod_en              : true
+                    channel             : L3-11
+                    attenuation         : 20                        # (dB)
+                    lo_enabled          : true
+                    lo_frequency        : 5_052_833_073             # (Hz) from 2e9 to 18e9
+                    gain                : 0.570                      # for path0 and path1 -1.0<=v<=1.0
                 o2: # qubit q2
-                    attenuation                  : 20 # (dB)
-                    lo_enabled                   : true
-                    lo_frequency                 : 5_995_371_914 # (Hz) from 2e9 to 18e9
-                    gain                         : 0.655 # for path0 and path1 -1.0<=v<=1.0
-                    hardware_mod_en              : true
-
-            channel_port_map:
-                'L3-11': o1 # q1
-                'L3-12': o2 # q2
+                    channel             : L3-12
+                    attenuation         : 20                        # (dB)
+                    lo_enabled          : true
+                    lo_frequency        : 5_995_371_914             # (Hz) from 2e9 to 18e9
+                    gain                : 0.655                     # for path0 and path1 -1.0<=v<=1.0
 
     qcm_rf3:
         lib: qblox
@@ -159,21 +158,17 @@ instruments:
         settings:
             ports:
                 o1: # qubit q3
-                    attenuation                  : 20 # (dB)
-                    lo_enabled                   : true
-                    lo_frequency                 : 6_961_018_001 # (Hz) from 2e9 to 18e9
-                    gain                         : 0.550 # for path0 and path1 -1.0<=v<=1.0
-                    hardware_mod_en              : true
+                    channel             : L3-13
+                    attenuation         : 20                        # (dB)
+                    lo_enabled          : true
+                    lo_frequency        : 6_961_018_001             # (Hz) from 2e9 to 18e9
+                    gain                : 0.550                     # for path0 and path1 -1.0<=v<=1.0
                 o2: # qubit q4
-                    attenuation                  : 20 # (dB)
-                    lo_enabled                   : true
-                    lo_frequency                 : 6_786_543_060 # (Hz) from 2e9 to 18e9
-                    gain                         : 0.596 # for path0 and path1 -1.0<=v<=1.0
-                    hardware_mod_en              : true
-
-            channel_port_map:
-                'L3-13': o1 # 1
-                'L3-14': o2 # 0
+                    channel             : L3-14
+                    attenuation         : 20                        # (dB)
+                    lo_enabled          : true
+                    lo_frequency        : 6_786_543_060             # (Hz) from 2e9 to 18e9
+                    gain                : 0.596                     # for path0 and path1 -1.0<=v<=1.0
 
     #Cluster QCM usado para bias mediante el offset
     qcm_bb1:
@@ -183,11 +178,8 @@ instruments:
         roles: [control]
         settings:
             ports:
-                o1: {gain: 0.5, offset: 0.5507, hardware_mod_en: false} #q0
-                o2: {gain: 0, offset: 0.0, hardware_mod_en: false} #not used
-                o3: {gain: 0, offset: 0.0, hardware_mod_en: false} #not used
-                o4: {gain: 0, offset: 0.0, hardware_mod_en: false} #not used
-            channel_port_map: {L4-5: o1, L4-6: o2, L4-7: o3, L4-8: o4}
+                o1: {channel: L4-5,gain: 0.5, offset: 0.5507, qubit: 0} #q0
+                # o4: {channel: L4-3, gain: 0.5, offset:  0.0, qubit: 3} #q3 oscilloscope
 
     #Cluster QCM usado para bias mediante el offset
     qcm_bb2:
@@ -197,11 +189,10 @@ instruments:
         roles: [control]
         settings:
             ports:
-                o1: {gain: 0.5, offset: 0.2227, hardware_mod_en: false} #q1
-                o2: {gain: 0.5, offset: -0.3780, hardware_mod_en: false} #q2
-                o3: {gain: 0.5, offset: -0.8899, hardware_mod_en: false} #q3
-                o4: {gain: 0.5, offset: 0.5890, hardware_mod_en: false} #q4
-            channel_port_map: {L4-1: o1, L4-2: o2, L4-3: o3, L4-4: o4}
+                o1: {channel: L4-1, gain: 0.5, offset: 0.2227, qubit: 1} #q1
+                o2: {channel: L4-2, gain: 0.5, offset: -0.3780, qubit: 2} #q2
+                o3: {channel: L4-3, gain: 0.5, offset: -0.8899, qubit: 3} #q3
+                o4: {channel: L4-4, gain: 0.5, offset: 0.5890, qubit: 4} #q4
 
     twpa_pump:
         lib: rohde_schwarz
@@ -209,7 +200,7 @@ instruments:
         address: 192.168.0.37
         roles: [other]
         settings:
-            frequency: 6_535_900_000 # Hz
+            frequency: 6_535_900_000 # 6_478_250_000 # Hz
             power: 4 # dBm
 
 native_gates:
@@ -339,6 +330,7 @@ native_gates:
             - type: virtual_z
               phase: -0.041
               qubit: 2
+
         2-0:
             CZ:
             - duration: 28
@@ -347,33 +339,6 @@ native_gates:
               qubit: 2
               relative_start: 0
               type: qf
-            - duration: 20
-              amplitude: 0
-              shape: Rectangular())
-              qubit: 2
-              relative_start: 28
-              type: qf
-            - type: virtual_z
-              phase: -3.491
-              qubit: 2
-
-            - duration: 28
-              amplitude: 0
-              shape: Rectangular())
-              qubit: 0
-              relative_start: 0
-              type: qf
-            - duration: 20
-              amplitude: 0
-              shape: Rectangular())
-              qubit: 0
-              relative_start: 28
-              type: qf
-            - type: virtual_z
-              phase: -0.013
-              qubit: 0
-
-
 
 
 characterization:
@@ -381,7 +346,7 @@ characterization:
         0:
             readout_frequency: 7_212_299_307
             drive_frequency: 5_050_304_836
-            # anharmonicity: 291_463_266
+            anharmonicity: 291_463_266
             T1: 5_857
             T2: 0
             state0_voltage: 0.0
@@ -392,7 +357,7 @@ characterization:
         1:
             readout_frequency: 7_452_990_931
             drive_frequency: 4_852_833_073
-            # anharmonicity: 292_584_018
+            anharmonicity: 292_584_018
             T1: 1_253
             T2: 0
             state0_voltage: 0.0
@@ -403,7 +368,7 @@ characterization:
         2:
             readout_frequency: 7_655_083_068
             drive_frequency: 5_795_371_914
-            # anharmonicity: 276_187_576
+            anharmonicity: 276_187_576
             T1: 4_563
             T2: 0
             state0_voltage: 0.0
@@ -414,7 +379,7 @@ characterization:
         3:
             readout_frequency: 7_803_441_221
             drive_frequency: 6_761_018_001
-            # anharmonicity: 262_310_994
+            anharmonicity: 262_310_994
             T1: 4_232
             T2: 0
             state0_voltage: 0.0
@@ -425,7 +390,7 @@ characterization:
         4:
             readout_frequency: 8_058_947_261
             drive_frequency: 6_586_543_060
-            # anharmonicity: 261_390_626
+            anharmonicity: 261_390_626
             T1: 492
             T2: 0
             state0_voltage: 0.0
@@ -436,7 +401,7 @@ characterization:
         5:
             readout_frequency: 7_118_627_658
             drive_frequency: 4_700_000_000
-            # anharmonicity: 300_000_000
+            anharmonicity: 300_000_000
             T1: 0
             T2: 0
             state0_voltage: 0.0

--- a/qw5q_gold.yml
+++ b/qw5q_gold.yml
@@ -2,7 +2,7 @@ nqubits: 5
 description: 5-qubit device at XLD fridge, controlled with qblox cluster rf.
 
 settings:
-    nshots: 1024
+    nshots: 4000
     relaxation_time: 20_000
     sampling_rate: 1_000_000_000
 
@@ -11,30 +11,6 @@ qubits: [0, 1, 2, 3, 4, 5]
 resonator_type: 2D
 
 topology: [[0, 2], [1, 2], [2, 3], [2, 4]]
-
-# Drive:
-# L3-15:mod8-o1 q0
-# L3-11:mod3-o1 q1
-# L3-12:mod3-o2 q2
-# L3-13:mod4-o1 q3
-# L3-14:mod4-o2 q4
-
-
-# Flux:
-# L4-5:mod5-o1 q0
-# L4-1:mod2-o1 q1
-# L4-2:mod2-o2 q2
-# L4-3:mod2-o3 q3
-# L4-4:mod2-o4 q4
-
-
-# Readout out:
-# L3-25:mod12 and mod10 (out)
-# L2-25:mod12 and mod10 (in)
-
-# Cluster IP:
-# 192.168.0.6
-
 
 # no bias line, using qblox offset from qcm_bbc
 channels: [
@@ -82,11 +58,11 @@ instruments:
 
             classification_parameters:
                 0:  # qubit id
-                    rotation_angle              : 268.023                   # in degrees 0.0<=v<=360.0
-                    threshold                   : 0.003503                  # in V
+                    rotation_angle              : 269.907                   # in degrees 0.0<=v<=360.0
+                    threshold                   : 0.003312                  # in V
                 1:  # qubit id
-                    rotation_angle              : 30.478                   # in degrees 0.0<=v<=360.0
-                    threshold                   : 0.002465                  # in V
+                    rotation_angle              : 37.712                   # in degrees 0.0<=v<=360.0
+                    threshold                   : 0.002625                  # in V
 
 
             channel_port_map:   # Refrigerator Channel : Instrument port
@@ -114,14 +90,14 @@ instruments:
 
             classification_parameters:
                 2:  # qubit id
-                    rotation_angle              : 343.894                    # in degrees 0.0<=v<=360.0
-                    threshold                   : 0.002606                  # in V
+                    rotation_angle              : 58.116                    # in degrees 0.0<=v<=360.0
+                    threshold                   : 0.003047                  # in V
                 3:  # qubit id
-                    rotation_angle              : 359.065                    # in degrees 0.0<=v<=360.0
-                    threshold                   : 0.003387                  # in V
+                    rotation_angle              : 21.968                    # in degrees 0.0<=v<=360.0
+                    threshold                   : 0.003540                  # in V
                 4:  # qubit id
-                    rotation_angle              : 283.970                   # in degrees 0.0<=v<=360.0
-                    threshold                   : 0.000889                  # in V
+                    rotation_angle              : 216.618                   # in degrees 0.0<=v<=360.0
+                    threshold                   : 0.001338                  # in V
 
             channel_port_map:   # Refrigerator Channel : Instrument port
                 'L3-25b' : o1    # IQ Port = out0 & out1
@@ -137,7 +113,7 @@ instruments:
                 o1: # qubit q0
                     attenuation                  : 20 # (dB) # should be multiple of 2
                     lo_enabled                   : true
-                    lo_frequency                 : 5_245_070_000 # (Hz) from 2e9 to 18e9
+                    lo_frequency                 : 5_250_304_836 # (Hz) from 2e9 to 18e9
                     gain                         : 0.470 # for path0 and path1 -1.0<=v<=1.0
                     hardware_mod_en              : true
                 o2: # not used
@@ -150,6 +126,7 @@ instruments:
             channel_port_map:
                 'L3-15': o1 # q0
                 'L3-16': o2 # not used port
+
     qcm_rf2:
         lib: qblox
         class: ClusterQCM_RF
@@ -160,19 +137,20 @@ instruments:
                 o1: # qubit q1
                     attenuation                  : 20 # (dB)
                     lo_enabled                   : true
-                    lo_frequency                 : 5_052_280_321 # (Hz) from 2e9 to 18e9
+                    lo_frequency                 : 5_052_833_073 # (Hz) from 2e9 to 18e9
                     gain                         : 0.570 # for path0 and path1 -1.0<=v<=1.0
                     hardware_mod_en              : true
                 o2: # qubit q2
                     attenuation                  : 20 # (dB)
                     lo_enabled                   : true
-                    lo_frequency                 : 5_994_176_000 # (Hz) from 2e9 to 18e9
+                    lo_frequency                 : 5_995_371_914 # (Hz) from 2e9 to 18e9
                     gain                         : 0.655 # for path0 and path1 -1.0<=v<=1.0
                     hardware_mod_en              : true
 
             channel_port_map:
                 'L3-11': o1 # q1
                 'L3-12': o2 # q2
+
     qcm_rf3:
         lib: qblox
         class: ClusterQCM_RF
@@ -183,21 +161,19 @@ instruments:
                 o1: # qubit q3
                     attenuation                  : 20 # (dB)
                     lo_enabled                   : true
-                    lo_frequency                 : 6_960_050_000 # (Hz) from 2e9 to 18e9
+                    lo_frequency                 : 6_961_018_001 # (Hz) from 2e9 to 18e9
                     gain                         : 0.550 # for path0 and path1 -1.0<=v<=1.0
                     hardware_mod_en              : true
                 o2: # qubit q4
                     attenuation                  : 20 # (dB)
                     lo_enabled                   : true
-                    lo_frequency                 : 6_785_145_857 # (Hz) from 2e9 to 18e9
+                    lo_frequency                 : 6_786_543_060 # (Hz) from 2e9 to 18e9
                     gain                         : 0.596 # for path0 and path1 -1.0<=v<=1.0
                     hardware_mod_en              : true
 
             channel_port_map:
                 'L3-13': o1 # 1
                 'L3-14': o2 # 0
-
-
 
     #Cluster QCM usado para bias mediante el offset
     qcm_bb1:
@@ -207,7 +183,7 @@ instruments:
         roles: [control]
         settings:
             ports:
-                o1: {gain: 0.5, offset: -0.0884, hardware_mod_en: false} #q0
+                o1: {gain: 0.5, offset: 0.5507, hardware_mod_en: false} #q0
                 o2: {gain: 0, offset: 0.0, hardware_mod_en: false} #not used
                 o3: {gain: 0, offset: 0.0, hardware_mod_en: false} #not used
                 o4: {gain: 0, offset: 0.0, hardware_mod_en: false} #not used
@@ -221,10 +197,10 @@ instruments:
         roles: [control]
         settings:
             ports:
-                o1: {gain: 0.5, offset:  0.5592, hardware_mod_en: false} #q1
-                o2: {gain: 0.5, offset: 0.1967, hardware_mod_en: false} #q2
-                o3: {gain: 0.5, offset:  0.7557, hardware_mod_en: false} #q3
-                o4: {gain: 0.5, offset: 0.4555, hardware_mod_en: false} #q4
+                o1: {gain: 0.5, offset: 0.2227, hardware_mod_en: false} #q1
+                o2: {gain: 0.5, offset: -0.3780, hardware_mod_en: false} #q2
+                o3: {gain: 0.5, offset: -0.8899, hardware_mod_en: false} #q3
+                o4: {gain: 0.5, offset: 0.5890, hardware_mod_en: false} #q4
             channel_port_map: {L4-1: o1, L4-2: o2, L4-3: o3, L4-4: o4}
 
     twpa_pump:
@@ -233,8 +209,8 @@ instruments:
         address: 192.168.0.37
         roles: [other]
         settings:
-            frequency: 6_478_250_000 # Hz
-            power: 3.5 # dBm
+            frequency: 6_535_900_000 # Hz
+            power: 4 # dBm
 
 native_gates:
     single_qubit:
@@ -242,75 +218,75 @@ native_gates:
             RX:
                 duration: 40                   # should be multiple of 4
                 amplitude: 0.5028
-                frequency: 5_045_070_000    # qubit frequency
+                frequency: 5_050_304_836    # qubit frequency
                 if_frequency: -200_000_000    # difference in qubit frequency
                 shape: Gaussian(5)
                 type: qd                    # qubit drive
             MZ:
                 duration: 2000
                 amplitude: 0.1
-                frequency: 7_212_362_551     # resonator frequency
-                if_frequency: -42_637_449    # difference in resonator frequency
+                frequency: 7_212_299_307     # resonator frequency
+                if_frequency: -42_700_693    # difference in resonator frequency
                 shape: Rectangular()
                 type: ro                    # readout
         1: # qubit id
             RX:
                 duration: 40                  # should be multiple of 4
                 amplitude: 0.5078
-                frequency: 4_852_280_321    # qubit frequency
+                frequency: 4_852_833_073    # qubit frequency
                 if_frequency: -200_000_000    # difference in qubit frequency
                 shape: Gaussian(5)
                 type: qd                    # qubit drive
             MZ:
                 duration: 2000
                 amplitude: 0.2
-                frequency: 7_453_149_599    # resonator frequency
-                if_frequency: 198_149_599    # difference in resonator frequency
+                frequency: 7_452_990_931    # resonator frequency
+                if_frequency: 197_990_931    # difference in resonator frequency
                 shape: Rectangular()
                 type: ro                    # readout
         2: # qubit id
             RX:
                 duration: 40                   # should be multiple of 4
                 amplitude: 0.5016
-                frequency: 5_794_176_000   # qubit frequency
+                frequency: 5_795_371_914   # qubit frequency
                 if_frequency: -200_000_000    # difference in qubit frequency
                 shape: Gaussian(5)
                 type: qd                    # qubit drive
             MZ:
                 duration: 2000
                 amplitude: 0.25
-                frequency: 7_655_110_446    # resonator frequency
-                if_frequency: -194_889_554    # difference in resonator frequency
+                frequency: 7_655_083_068    # resonator frequency
+                if_frequency: -194_916_932    # difference in resonator frequency
                 shape: Rectangular()
                 type: ro                    # readout
         3: # qubit id
             RX:
                 duration: 40                   # should be multiple of 4
                 amplitude: 0.5026
-                frequency: 6_760_050_000    # qubit frequency
+                frequency: 6_761_018_001    # qubit frequency
                 if_frequency: -200_000_000    # difference in qubit frequency
                 shape: Gaussian(5)
                 type: qd                    # qubit drive
             MZ:
                 duration: 2000
                 amplitude: 0.2
-                frequency: 7_803_377_426    # resonator frequency
-                if_frequency: -46_622_574    # difference in resonator frequency
+                frequency: 7_803_441_221    # resonator frequency
+                if_frequency: -46_558_779    # difference in resonator frequency
                 shape: Rectangular()
                 type: ro                    # readout
         4: # qubit id
             RX:
                 duration: 40                # should be multiple of 4
                 amplitude: 0.5172
-                frequency: 6_585_145_857    # qubit frequency
+                frequency: 6_586_543_060    # qubit frequency
                 if_frequency: -200_000_000    # difference in qubit frequency
                 shape: Gaussian(5)
                 type: qd                    # qubit drive
             MZ:
                 duration: 2000
                 amplitude: 0.4
-                frequency: 8_058_739_833      # resonator frequency
-                if_frequency: 208_739_833    # difference in resonator frequency
+                frequency: 8_058_947_261      # resonator frequency
+                if_frequency: 208_947_261    # difference in resonator frequency
                 shape: Rectangular()
                 type: ro                    # readout
         5: # qubit id
@@ -324,8 +300,8 @@ native_gates:
             MZ:
                 duration: 2000
                 amplitude: 0.2
-                frequency: 7_118_627_416      # resonator frequency
-                if_frequency: -136_372_584    # difference in resonator frequency
+                frequency: 7_118_627_658      # resonator frequency
+                if_frequency: -136_372_342    # difference in resonator frequency
                 shape: Rectangular()
                 type: ro                    # readout
 
@@ -333,7 +309,7 @@ native_gates:
         3-2:
             CZ:
             - duration: 32
-              amplitude: -0.6010
+              amplitude: -0.6025
               shape: Exponential(12, 5000, 0.1)
               qubit: 3
               relative_start: 0
@@ -345,7 +321,7 @@ native_gates:
               relative_start: 32
               type: qf
             - type: virtual_z
-              phase: -3.862
+              phase: -3.630
               qubit: 3
 
             - duration: 32
@@ -361,7 +337,7 @@ native_gates:
               relative_start: 32
               type: qf
             - type: virtual_z
-              phase: -0.095
+              phase: -0.041
               qubit: 2
         2-0:
             CZ:
@@ -403,62 +379,62 @@ native_gates:
 characterization:
     single_qubit:
         0:
-            readout_frequency: 7_212_362_551
-            drive_frequency: 5_045_070_000
-            # anharmonicity: 291_451_184
+            readout_frequency: 7_212_299_307
+            drive_frequency: 5_050_304_836
+            # anharmonicity: 291_463_266
             T1: 5_857
             T2: 0
             state0_voltage: 0.0
             state1_voltage: 0.0
             mean_gnd_states: (-0.0+0.0j)
             mean_exc_states: (0.0+0.0j)
-            sweetspot: -0.0884
+            sweetspot: 0.5507
         1:
-            readout_frequency: 7_453_149_599
-            drive_frequency: 4_852_280_321
-            # anharmonicity: 291_965_010
+            readout_frequency: 7_452_990_931
+            drive_frequency: 4_852_833_073
+            # anharmonicity: 292_584_018
             T1: 1_253
             T2: 0
             state0_voltage: 0.0
             state1_voltage: 0.0
             mean_gnd_states: (-0.0+0.0j)
             mean_exc_states: (0.0+0.0j)
-            sweetspot: 0.5592
+            sweetspot: 0.2227
         2:
-            readout_frequency: 7_655_110_446
-            drive_frequency: 5_794_176_000
-            # anharmonicity: 275_392_460
+            readout_frequency: 7_655_083_068
+            drive_frequency: 5_795_371_914
+            # anharmonicity: 276_187_576
             T1: 4_563
             T2: 0
             state0_voltage: 0.0
             state1_voltage: 0.0
             mean_gnd_states: (-0.0+0.0j)
             mean_exc_states: (0.0+0.0j)
-            sweetspot: 0.1967
+            sweetspot: -0.3780
         3:
-            readout_frequency: 7_803_377_426
-            drive_frequency: 6_760_050_000
-            # anharmonicity: 261_797_410
+            readout_frequency: 7_803_441_221
+            drive_frequency: 6_761_018_001
+            # anharmonicity: 262_310_994
             T1: 4_232
             T2: 0
             state0_voltage: 0.0
             state1_voltage: 0.0
             mean_gnd_states: (-0.0+0.0j)
             mean_exc_states: (0.0+0.0j)
-            sweetspot: 0.7557
+            sweetspot: -0.8899
         4:
-            readout_frequency: 8_058_739_833
-            drive_frequency: 6_585_145_857
-            # anharmonicity: 253_106_666
+            readout_frequency: 8_058_947_261
+            drive_frequency: 6_586_543_060
+            # anharmonicity: 261_390_626
             T1: 492
             T2: 0
             state0_voltage: 0.0
             state1_voltage: 0.0
             mean_gnd_states: (-0.0+0.0j)
             mean_exc_states: (0.0+0.0j)
-            sweetspot: 0.4555
+            sweetspot: 0.5890
         5:
-            readout_frequency: 7_118_627_416
+            readout_frequency: 7_118_627_658
             drive_frequency: 4_700_000_000
             # anharmonicity: 300_000_000
             T1: 0

--- a/qw5q_gold.yml
+++ b/qw5q_gold.yml
@@ -1,411 +1,73 @@
 nqubits: 5
-description: 5-qubit device at XLD fridge, controlled with qblox cluster rf.
-
-settings:
-    nshots: 4000
-    relaxation_time: 20_000
-    sampling_rate: 1_000_000_000
-
+description: QuantWare 5-qubit device at XLD fridge.
+settings: {nshots: 1024, sampling_rate: 1000000000, relaxation_time: 20000}
 qubits: [0, 1, 2, 3, 4, 5]
-
+topology:
+- [0, 2]
+- [1, 2]
+- [2, 3]
+- [2, 4]
 resonator_type: 2D
-
-topology: [[0, 2], [1, 2], [2, 3], [2, 4]]
-
-# Drive:
-# L3-15:mod8-o1 q0
-# L3-11:mod3-o1 q1
-# L3-12:mod3-o2 q2
-# L3-13:mod4-o1 q3
-# L3-14:mod4-o2 q4
-
-
-# Flux:
-# L4-5:mod5-o1 q0
-# L4-1:mod2-o1 q1
-# L4-2:mod2-o2 q2
-# L4-3:mod2-o3 q3
-# L4-4:mod2-o4 q4
-
-
-# Readout out:
-# L3-25:mod12 and mod10 (out)
-# L2-25:mod12 and mod10 (in)
-
-# Cluster IP:
-# 192.168.0.6
-
-
-# no bias line, using qblox offset from qcm_bbc
-channels: [
-  'L2-5a','L2-5b', 'L3-25a', 'L3-25b', #RO channels: Ro lines L2-5 and L3-25 splitted
-  'L3-15', 'L3-11', 'L3-12', 'L3-13', 'L3-14', 'L3-16', # Drive channels q0, q1, q2, q3, q4 | not used ports label: L3-16
-  'L4-5', 'L4-1', 'L4-2', 'L4-3', 'L4-4', 'L4-6', 'L4-7', 'L4-8', # Flux channels q0, q1, q2, q3, q4 | not used labels: 'L4-6', 'L4-7', 'L4-8'
-]
-
-# [ReadOut, QubitDrive, QubitFlux, QubitBias]
-qubit_channel_map:
-    0:   [L3-25a, L3-15, L4-5, null] #q0
-    1:   [L3-25a, L3-11, L4-1, null] #q1
-    2:   [L3-25b, L3-12, L4-2, null] #q2
-    3:   [L3-25b, L3-13, L4-3, null] #q3
-    4:   [L3-25b, L3-14, L4-4, null] #q4
-    5:   [L3-25a,  null, null, null] #q5 witness
-
-instruments:
-    cluster:
-        lib: qblox
-        class: Cluster
-        address: 192.168.0.6
-        roles: [other]
-        settings:
-            reference_clock_source      : internal                      # external or internal
-
-    qrm_rf1: # ReadOut module 10 controllin qubits q0, q1, q5
-        lib: qblox
-        class: ClusterQRM_RF
-        address: 192.168.0.6:10
-        roles: [readout]
-        settings:
-            ports:
-                o1:
-                    channel                     : L3-25a
-                    attenuation                 : 38                        # should be multiple of 2
-                    lo_enabled                  : true
-                    lo_frequency                : 7_255_000_000             # (Hz) from 2e9 to 18e9
-                    gain                        : 0.6                       # for path0 and path1 -1.0<=v<=1.0
-                i1:
-                    channel                     : L2-5a
-                    acquisition_hold_off        : 500                       # must be multiple of 4
-                    acquisition_duration        : 900
-
-            classification_parameters:
-                0:  # qubit id
-                    rotation_angle              : 269.907                   # in degrees 0.0<=v<=360.0
-                    threshold                   : 0.003312                  # in V
-                1:  # qubit id
-                    rotation_angle              : 37.712                   # in degrees 0.0<=v<=360.0
-                    threshold                   : 0.002625                  # in V
-
-    qrm_rf2: # ReadOut module 12: controlling qubits q2, q3, q4
-        lib: qblox
-        class: ClusterQRM_RF
-        address: 192.168.0.6:12
-        roles: [readout]
-        settings:
-            ports:
-                o1:
-                    channel                     : L3-25b
-                    attenuation                 : 32                        # should be multiple of 2
-                    lo_enabled                  : true
-                    lo_frequency                : 7_850_000_000             # (Hz) from 2e9 to 18e9
-                    gain                        : 0.6                       # for path0 and path1 -1.0<=v<=1.0
-                i1:
-                    channel                     : L2-5b
-                    acquisition_hold_off        : 500
-                    acquisition_duration        : 900
-
-            classification_parameters:
-                2:  # qubit id
-                    rotation_angle              : 58.116                    # in degrees 0.0<=v<=360.0
-                    threshold                   : 0.003047                  # in V
-                3:  # qubit id
-                    rotation_angle              : 21.968                    # in degrees 0.0<=v<=360.0
-                    threshold                   : 0.003540                  # in V
-                4:  # qubit id
-                    rotation_angle              : 216.618                   # in degrees 0.0<=v<=360.0
-                    threshold                   : 0.001338                  # in V
-
-    qcm_rf1:
-        lib: qblox
-        class: ClusterQCM_RF
-        address: 192.168.0.6:8
-        roles: [control]
-        settings:
-            ports:
-                o1: # qubit q0
-                    channel             : L3-15
-                    attenuation         : 20                        # (dB) # should be multiple of 2
-                    lo_enabled          : true
-                    lo_frequency        : 5_250_304_836             # (Hz) from 2e9 to 18e9
-                    gain                : 0.470                     # for path0 and path1 -1.0<=v<=1.0
-
-    qcm_rf2:
-        lib: qblox
-        class: ClusterQCM_RF
-        address: 192.168.0.6:3
-        roles: [control]
-        settings:
-            ports:
-                o1: # qubit q1
-                    channel             : L3-11
-                    attenuation         : 20                        # (dB)
-                    lo_enabled          : true
-                    lo_frequency        : 5_052_833_073             # (Hz) from 2e9 to 18e9
-                    gain                : 0.570                      # for path0 and path1 -1.0<=v<=1.0
-                o2: # qubit q2
-                    channel             : L3-12
-                    attenuation         : 20                        # (dB)
-                    lo_enabled          : true
-                    lo_frequency        : 5_995_371_914             # (Hz) from 2e9 to 18e9
-                    gain                : 0.655                     # for path0 and path1 -1.0<=v<=1.0
-
-    qcm_rf3:
-        lib: qblox
-        class: ClusterQCM_RF
-        address: 192.168.0.6:4
-        roles: [control]
-        settings:
-            ports:
-                o1: # qubit q3
-                    channel             : L3-13
-                    attenuation         : 20                        # (dB)
-                    lo_enabled          : true
-                    lo_frequency        : 6_961_018_001             # (Hz) from 2e9 to 18e9
-                    gain                : 0.550                     # for path0 and path1 -1.0<=v<=1.0
-                o2: # qubit q4
-                    channel             : L3-14
-                    attenuation         : 20                        # (dB)
-                    lo_enabled          : true
-                    lo_frequency        : 6_786_543_060             # (Hz) from 2e9 to 18e9
-                    gain                : 0.596                     # for path0 and path1 -1.0<=v<=1.0
-
-    #Cluster QCM usado para bias mediante el offset
-    qcm_bb1:
-        lib: qblox
-        class: ClusterQCM
-        address: 192.168.0.6:5
-        roles: [control]
-        settings:
-            ports:
-                o1: {channel: L4-5,gain: 0.5, offset: 0.5507, qubit: 0} #q0
-                # o4: {channel: L4-3, gain: 0.5, offset:  0.0, qubit: 3} #q3 oscilloscope
-
-    #Cluster QCM usado para bias mediante el offset
-    qcm_bb2:
-        lib: qblox
-        class: ClusterQCM
-        address: 192.168.0.6:2
-        roles: [control]
-        settings:
-            ports:
-                o1: {channel: L4-1, gain: 0.5, offset: 0.2227, qubit: 1} #q1
-                o2: {channel: L4-2, gain: 0.5, offset: -0.3780, qubit: 2} #q2
-                o3: {channel: L4-3, gain: 0.5, offset: -0.8899, qubit: 3} #q3
-                o4: {channel: L4-4, gain: 0.5, offset: 0.5890, qubit: 4} #q4
-
-    twpa_pump:
-        lib: rohde_schwarz
-        class: SGS100A
-        address: 192.168.0.37
-        roles: [other]
-        settings:
-            frequency: 6_535_900_000 # 6_478_250_000 # Hz
-            power: 4 # dBm
-
 native_gates:
     single_qubit:
-        0: # qubit id
-            RX:
-                duration: 40                   # should be multiple of 4
-                amplitude: 0.5028
-                frequency: 5_050_304_836    # qubit frequency
-                if_frequency: -200_000_000    # difference in qubit frequency
-                shape: Gaussian(5)
-                type: qd                    # qubit drive
-            MZ:
-                duration: 2000
-                amplitude: 0.1
-                frequency: 7_212_299_307     # resonator frequency
-                if_frequency: -42_700_693    # difference in resonator frequency
-                shape: Rectangular()
-                type: ro                    # readout
-        1: # qubit id
-            RX:
-                duration: 40                  # should be multiple of 4
-                amplitude: 0.5078
-                frequency: 4_852_833_073    # qubit frequency
-                if_frequency: -200_000_000    # difference in qubit frequency
-                shape: Gaussian(5)
-                type: qd                    # qubit drive
-            MZ:
-                duration: 2000
-                amplitude: 0.2
-                frequency: 7_452_990_931    # resonator frequency
-                if_frequency: 197_990_931    # difference in resonator frequency
-                shape: Rectangular()
-                type: ro                    # readout
-        2: # qubit id
-            RX:
-                duration: 40                   # should be multiple of 4
-                amplitude: 0.5016
-                frequency: 5_795_371_914   # qubit frequency
-                if_frequency: -200_000_000    # difference in qubit frequency
-                shape: Gaussian(5)
-                type: qd                    # qubit drive
-            MZ:
-                duration: 2000
-                amplitude: 0.25
-                frequency: 7_655_083_068    # resonator frequency
-                if_frequency: -194_916_932    # difference in resonator frequency
-                shape: Rectangular()
-                type: ro                    # readout
-        3: # qubit id
-            RX:
-                duration: 40                   # should be multiple of 4
-                amplitude: 0.5026
-                frequency: 6_761_018_001    # qubit frequency
-                if_frequency: -200_000_000    # difference in qubit frequency
-                shape: Gaussian(5)
-                type: qd                    # qubit drive
-            MZ:
-                duration: 2000
-                amplitude: 0.2
-                frequency: 7_803_441_221    # resonator frequency
-                if_frequency: -46_558_779    # difference in resonator frequency
-                shape: Rectangular()
-                type: ro                    # readout
-        4: # qubit id
-            RX:
-                duration: 40                # should be multiple of 4
-                amplitude: 0.5172
-                frequency: 6_586_543_060    # qubit frequency
-                if_frequency: -200_000_000    # difference in qubit frequency
-                shape: Gaussian(5)
-                type: qd                    # qubit drive
-            MZ:
-                duration: 2000
-                amplitude: 0.4
-                frequency: 8_058_947_261      # resonator frequency
-                if_frequency: 208_947_261    # difference in resonator frequency
-                shape: Rectangular()
-                type: ro                    # readout
-        5: # qubit id
-            RX:
-                duration: 40                # should be multiple of 4
-                amplitude: 0.5
-                frequency: 4_700_000_000    # qubit frequency
-                if_frequency: -200_000_000    # difference in qubit frequency
-                shape: Gaussian(5)
-                type: qd                    # qubit drive
-            MZ:
-                duration: 2000
-                amplitude: 0.2
-                frequency: 7_118_627_658      # resonator frequency
-                if_frequency: -136_372_342    # difference in resonator frequency
-                shape: Rectangular()
-                type: ro                    # readout
-
+        0:
+            RX: {duration: 40, amplitude: 0.5028, frequency: 5050304836, shape: Gaussian(5),
+                type: qd, start: 0, phase: 0}
+            MZ: {duration: 2000, amplitude: 0.1, frequency: 7212299307, shape: Rectangular(),
+                type: ro, start: 0, phase: 0}
+        1:
+            RX: {duration: 40, amplitude: 0.5078, frequency: 4852833073, shape: Gaussian(5),
+                type: qd}
+            MZ: {duration: 2000, amplitude: 0.2, frequency: 7452990931, shape: Rectangular(),
+                type: ro}
+        2:
+            RX: {duration: 40, amplitude: 0.5016, frequency: 5795371914, shape: Gaussian(5),
+                type: qd}
+            MZ: {duration: 2000, amplitude: 0.25, frequency: 7655083068, shape: Rectangular(),
+                type: ro}
+        3:
+            RX: {duration: 40, amplitude: 0.5026, frequency: 6761018001, shape: Gaussian(5),
+                type: qd}
+            MZ: {duration: 2000, amplitude: 0.2, frequency: 7803441221, shape: Rectangular(),
+                type: ro}
+        4:
+            RX: {duration: 40, amplitude: 0.5172, frequency: 6586543060, shape: Gaussian(5),
+                type: qd}
+            MZ: {duration: 2000, amplitude: 0.4, frequency: 8058947261, shape: Rectangular(),
+                type: ro}
+        5:
+            RX: {duration: 40, amplitude: 0.5, frequency: 4700000000, shape: Gaussian(5),
+                type: qd}
+            MZ: {duration: 2000, amplitude: 0.2, frequency: 7118627658, shape: Rectangular(),
+                type: ro}
     two_qubit:
         3-2:
             CZ:
-            - duration: 32
-              amplitude: -0.6025
-              shape: Exponential(12, 5000, 0.1)
-              qubit: 3
-              relative_start: 0
-              type: qf
-            - duration: 20
-              amplitude: 0
-              shape: Rectangular())
-              qubit: 3
-              relative_start: 32
-              type: qf
-            - type: virtual_z
-              phase: -3.630
-              qubit: 3
-
-            - duration: 32
-              amplitude: 0
-              shape: Rectangular())
-              qubit: 2
-              relative_start: 0
-              type: qf
-            - duration: 20
-              amplitude: 0
-              shape: Rectangular())
-              qubit: 2
-              relative_start: 32
-              type: qf
-            - type: virtual_z
-              phase: -0.041
-              qubit: 2
-
+            - {duration: 32, amplitude: -0.6025, shape: 'Exponential(12, 5000, 0.1)',
+                qubit: 3, relative_start: 0, type: qf}
+            - {duration: 20, amplitude: 0, shape: Rectangular()), qubit: 3, relative_start: 32,
+                type: qf}
+            - {type: virtual_z, phase: -3.63, qubit: 3}
+            - {duration: 32, amplitude: 0, shape: Rectangular()), qubit: 2, relative_start: 0,
+                type: qf}
+            - {duration: 20, amplitude: 0, shape: Rectangular()), qubit: 2, relative_start: 32,
+                type: qf}
+            - {type: virtual_z, phase: -0.041, qubit: 2}
         2-0:
             CZ:
-            - duration: 28
-              amplitude: -0.142
-              shape: Exponential(12, 5000, 0.1)
-              qubit: 2
-              relative_start: 0
-              type: qf
-
-
+            - {duration: 28, amplitude: -0.142, shape: 'Exponential(12, 5000, 0.1)',
+                qubit: 2, relative_start: 0, type: qf}
 characterization:
     single_qubit:
-        0:
-            readout_frequency: 7_212_299_307
-            drive_frequency: 5_050_304_836
-            anharmonicity: 291_463_266
-            T1: 5_857
-            T2: 0
-            state0_voltage: 0.0
-            state1_voltage: 0.0
-            mean_gnd_states: (-0.0+0.0j)
-            mean_exc_states: (0.0+0.0j)
-            sweetspot: 0.5507
-        1:
-            readout_frequency: 7_452_990_931
-            drive_frequency: 4_852_833_073
-            anharmonicity: 292_584_018
-            T1: 1_253
-            T2: 0
-            state0_voltage: 0.0
-            state1_voltage: 0.0
-            mean_gnd_states: (-0.0+0.0j)
-            mean_exc_states: (0.0+0.0j)
-            sweetspot: 0.2227
-        2:
-            readout_frequency: 7_655_083_068
-            drive_frequency: 5_795_371_914
-            anharmonicity: 276_187_576
-            T1: 4_563
-            T2: 0
-            state0_voltage: 0.0
-            state1_voltage: 0.0
-            mean_gnd_states: (-0.0+0.0j)
-            mean_exc_states: (0.0+0.0j)
-            sweetspot: -0.3780
-        3:
-            readout_frequency: 7_803_441_221
-            drive_frequency: 6_761_018_001
-            anharmonicity: 262_310_994
-            T1: 4_232
-            T2: 0
-            state0_voltage: 0.0
-            state1_voltage: 0.0
-            mean_gnd_states: (-0.0+0.0j)
-            mean_exc_states: (0.0+0.0j)
-            sweetspot: -0.8899
-        4:
-            readout_frequency: 8_058_947_261
-            drive_frequency: 6_586_543_060
-            anharmonicity: 261_390_626
-            T1: 492
-            T2: 0
-            state0_voltage: 0.0
-            state1_voltage: 0.0
-            mean_gnd_states: (-0.0+0.0j)
-            mean_exc_states: (0.0+0.0j)
-            sweetspot: 0.5890
-        5:
-            readout_frequency: 7_118_627_658
-            drive_frequency: 4_700_000_000
-            anharmonicity: 300_000_000
-            T1: 0
-            T2: 0
-            state0_voltage: 0.0
-            state1_voltage: 0.0
-            mean_gnd_states: (-0.0+0.0j)
-            mean_exc_states: (0.0+0.0j)
-            sweetspot: 0
+        0: {readout_frequency: 7212299307, drive_frequency: 5050304836, anharmonicity: 291463266,
+            T1: 5857, T2: 0, sweetspot: 0.5507, iq_angle: 99.758, threshold: 0.003933}
+        1: {readout_frequency: 7452990931, drive_frequency: 4852833073, anharmonicity: 292584018,
+            T1: 1253, T2: 0, sweetspot: 0.2227, iq_angle: 146.297, threshold: 0.003488}
+        2: {readout_frequency: 7655083068, drive_frequency: 5795371914, anharmonicity: 276187576,
+            T1: 4563, T2: 0, sweetspot: -0.378, iq_angle: 97.821, threshold: 0.002904}
+        3: {readout_frequency: 7803441221, drive_frequency: 6761018001, anharmonicity: 262310994,
+            T1: 4232, T2: 0, sweetspot: -0.8899, iq_angle: 91.209, threshold: 0.004318}
+        4: {readout_frequency: 8058947261, drive_frequency: 6586543060, anharmonicity: 261390626,
+            T1: 492, T2: 0, sweetspot: 0.589, iq_angle: 7.997, threshold: 0.002323}
+        5: {readout_frequency: 7118627658, drive_frequency: 4700000000, anharmonicity: 300000000,
+            T1: 0, T2: 0, sweetspot: 0, iq_angle: 0, threshold: 0.002}

--- a/qw5q_gold_old.yml
+++ b/qw5q_gold_old.yml
@@ -1,0 +1,411 @@
+nqubits: 5
+description: 5-qubit device at XLD fridge, controlled with qblox cluster rf.
+
+settings:
+    nshots: 4000
+    relaxation_time: 20_000
+    sampling_rate: 1_000_000_000
+
+qubits: [0, 1, 2, 3, 4, 5]
+
+resonator_type: 2D
+
+topology: [[0, 2], [1, 2], [2, 3], [2, 4]]
+
+# Drive:
+# L3-15:mod8-o1 q0
+# L3-11:mod3-o1 q1
+# L3-12:mod3-o2 q2
+# L3-13:mod4-o1 q3
+# L3-14:mod4-o2 q4
+
+
+# Flux:
+# L4-5:mod5-o1 q0
+# L4-1:mod2-o1 q1
+# L4-2:mod2-o2 q2
+# L4-3:mod2-o3 q3
+# L4-4:mod2-o4 q4
+
+
+# Readout out:
+# L3-25:mod12 and mod10 (out)
+# L2-25:mod12 and mod10 (in)
+
+# Cluster IP:
+# 192.168.0.6
+
+
+# no bias line, using qblox offset from qcm_bbc
+channels: [
+  'L2-5a','L2-5b', 'L3-25a', 'L3-25b', #RO channels: Ro lines L2-5 and L3-25 splitted
+  'L3-15', 'L3-11', 'L3-12', 'L3-13', 'L3-14', 'L3-16', # Drive channels q0, q1, q2, q3, q4 | not used ports label: L3-16
+  'L4-5', 'L4-1', 'L4-2', 'L4-3', 'L4-4', 'L4-6', 'L4-7', 'L4-8', # Flux channels q0, q1, q2, q3, q4 | not used labels: 'L4-6', 'L4-7', 'L4-8'
+]
+
+# [ReadOut, QubitDrive, QubitFlux, QubitBias]
+qubit_channel_map:
+    0:   [L3-25a, L3-15, L4-5, null] #q0
+    1:   [L3-25a, L3-11, L4-1, null] #q1
+    2:   [L3-25b, L3-12, L4-2, null] #q2
+    3:   [L3-25b, L3-13, L4-3, null] #q3
+    4:   [L3-25b, L3-14, L4-4, null] #q4
+    5:   [L3-25a,  null, null, null] #q5 witness
+
+instruments:
+    cluster:
+        lib: qblox
+        class: Cluster
+        address: 192.168.0.6
+        roles: [other]
+        settings:
+            reference_clock_source      : internal                      # external or internal
+
+    qrm_rf1: # ReadOut module 10 controllin qubits q0, q1, q5
+        lib: qblox
+        class: ClusterQRM_RF
+        address: 192.168.0.6:10
+        roles: [readout]
+        settings:
+            ports:
+                o1:
+                    channel                     : L3-25a
+                    attenuation                 : 38                        # should be multiple of 2
+                    lo_enabled                  : true
+                    lo_frequency                : 7_255_000_000             # (Hz) from 2e9 to 18e9
+                    gain                        : 0.6                       # for path0 and path1 -1.0<=v<=1.0
+                i1:
+                    channel                     : L2-5a
+                    acquisition_hold_off        : 500                       # must be multiple of 4
+                    acquisition_duration        : 900
+
+            classification_parameters:
+                0:  # qubit id
+                    rotation_angle              : 269.907                   # in degrees 0.0<=v<=360.0
+                    threshold                   : 0.003312                  # in V
+                1:  # qubit id
+                    rotation_angle              : 37.712                   # in degrees 0.0<=v<=360.0
+                    threshold                   : 0.002625                  # in V
+
+    qrm_rf2: # ReadOut module 12: controlling qubits q2, q3, q4
+        lib: qblox
+        class: ClusterQRM_RF
+        address: 192.168.0.6:12
+        roles: [readout]
+        settings:
+            ports:
+                o1:
+                    channel                     : L3-25b
+                    attenuation                 : 32                        # should be multiple of 2
+                    lo_enabled                  : true
+                    lo_frequency                : 7_850_000_000             # (Hz) from 2e9 to 18e9
+                    gain                        : 0.6                       # for path0 and path1 -1.0<=v<=1.0
+                i1:
+                    channel                     : L2-5b
+                    acquisition_hold_off        : 500
+                    acquisition_duration        : 900
+
+            classification_parameters:
+                2:  # qubit id
+                    rotation_angle              : 58.116                    # in degrees 0.0<=v<=360.0
+                    threshold                   : 0.003047                  # in V
+                3:  # qubit id
+                    rotation_angle              : 21.968                    # in degrees 0.0<=v<=360.0
+                    threshold                   : 0.003540                  # in V
+                4:  # qubit id
+                    rotation_angle              : 216.618                   # in degrees 0.0<=v<=360.0
+                    threshold                   : 0.001338                  # in V
+
+    qcm_rf1:
+        lib: qblox
+        class: ClusterQCM_RF
+        address: 192.168.0.6:8
+        roles: [control]
+        settings:
+            ports:
+                o1: # qubit q0
+                    channel             : L3-15
+                    attenuation         : 20                        # (dB) # should be multiple of 2
+                    lo_enabled          : true
+                    lo_frequency        : 5_250_304_836             # (Hz) from 2e9 to 18e9
+                    gain                : 0.470                     # for path0 and path1 -1.0<=v<=1.0
+
+    qcm_rf2:
+        lib: qblox
+        class: ClusterQCM_RF
+        address: 192.168.0.6:3
+        roles: [control]
+        settings:
+            ports:
+                o1: # qubit q1
+                    channel             : L3-11
+                    attenuation         : 20                        # (dB)
+                    lo_enabled          : true
+                    lo_frequency        : 5_052_833_073             # (Hz) from 2e9 to 18e9
+                    gain                : 0.570                      # for path0 and path1 -1.0<=v<=1.0
+                o2: # qubit q2
+                    channel             : L3-12
+                    attenuation         : 20                        # (dB)
+                    lo_enabled          : true
+                    lo_frequency        : 5_995_371_914             # (Hz) from 2e9 to 18e9
+                    gain                : 0.655                     # for path0 and path1 -1.0<=v<=1.0
+
+    qcm_rf3:
+        lib: qblox
+        class: ClusterQCM_RF
+        address: 192.168.0.6:4
+        roles: [control]
+        settings:
+            ports:
+                o1: # qubit q3
+                    channel             : L3-13
+                    attenuation         : 20                        # (dB)
+                    lo_enabled          : true
+                    lo_frequency        : 6_961_018_001             # (Hz) from 2e9 to 18e9
+                    gain                : 0.550                     # for path0 and path1 -1.0<=v<=1.0
+                o2: # qubit q4
+                    channel             : L3-14
+                    attenuation         : 20                        # (dB)
+                    lo_enabled          : true
+                    lo_frequency        : 6_786_543_060             # (Hz) from 2e9 to 18e9
+                    gain                : 0.596                     # for path0 and path1 -1.0<=v<=1.0
+
+    #Cluster QCM usado para bias mediante el offset
+    qcm_bb1:
+        lib: qblox
+        class: ClusterQCM
+        address: 192.168.0.6:5
+        roles: [control]
+        settings:
+            ports:
+                o1: {channel: L4-5,gain: 0.5, offset: 0.5507, qubit: 0} #q0
+                # o4: {channel: L4-3, gain: 0.5, offset:  0.0, qubit: 3} #q3 oscilloscope
+
+    #Cluster QCM usado para bias mediante el offset
+    qcm_bb2:
+        lib: qblox
+        class: ClusterQCM
+        address: 192.168.0.6:2
+        roles: [control]
+        settings:
+            ports:
+                o1: {channel: L4-1, gain: 0.5, offset: 0.2227, qubit: 1} #q1
+                o2: {channel: L4-2, gain: 0.5, offset: -0.3780, qubit: 2} #q2
+                o3: {channel: L4-3, gain: 0.5, offset: -0.8899, qubit: 3} #q3
+                o4: {channel: L4-4, gain: 0.5, offset: 0.5890, qubit: 4} #q4
+
+    twpa_pump:
+        lib: rohde_schwarz
+        class: SGS100A
+        address: 192.168.0.37
+        roles: [other]
+        settings:
+            frequency: 6_535_900_000 # 6_478_250_000 # Hz
+            power: 4 # dBm
+
+native_gates:
+    single_qubit:
+        0: # qubit id
+            RX:
+                duration: 40                   # should be multiple of 4
+                amplitude: 0.5028
+                frequency: 5_050_304_836    # qubit frequency
+                if_frequency: -200_000_000    # difference in qubit frequency
+                shape: Gaussian(5)
+                type: qd                    # qubit drive
+            MZ:
+                duration: 2000
+                amplitude: 0.1
+                frequency: 7_212_299_307     # resonator frequency
+                if_frequency: -42_700_693    # difference in resonator frequency
+                shape: Rectangular()
+                type: ro                    # readout
+        1: # qubit id
+            RX:
+                duration: 40                  # should be multiple of 4
+                amplitude: 0.5078
+                frequency: 4_852_833_073    # qubit frequency
+                if_frequency: -200_000_000    # difference in qubit frequency
+                shape: Gaussian(5)
+                type: qd                    # qubit drive
+            MZ:
+                duration: 2000
+                amplitude: 0.2
+                frequency: 7_452_990_931    # resonator frequency
+                if_frequency: 197_990_931    # difference in resonator frequency
+                shape: Rectangular()
+                type: ro                    # readout
+        2: # qubit id
+            RX:
+                duration: 40                   # should be multiple of 4
+                amplitude: 0.5016
+                frequency: 5_795_371_914   # qubit frequency
+                if_frequency: -200_000_000    # difference in qubit frequency
+                shape: Gaussian(5)
+                type: qd                    # qubit drive
+            MZ:
+                duration: 2000
+                amplitude: 0.25
+                frequency: 7_655_083_068    # resonator frequency
+                if_frequency: -194_916_932    # difference in resonator frequency
+                shape: Rectangular()
+                type: ro                    # readout
+        3: # qubit id
+            RX:
+                duration: 40                   # should be multiple of 4
+                amplitude: 0.5026
+                frequency: 6_761_018_001    # qubit frequency
+                if_frequency: -200_000_000    # difference in qubit frequency
+                shape: Gaussian(5)
+                type: qd                    # qubit drive
+            MZ:
+                duration: 2000
+                amplitude: 0.2
+                frequency: 7_803_441_221    # resonator frequency
+                if_frequency: -46_558_779    # difference in resonator frequency
+                shape: Rectangular()
+                type: ro                    # readout
+        4: # qubit id
+            RX:
+                duration: 40                # should be multiple of 4
+                amplitude: 0.5172
+                frequency: 6_586_543_060    # qubit frequency
+                if_frequency: -200_000_000    # difference in qubit frequency
+                shape: Gaussian(5)
+                type: qd                    # qubit drive
+            MZ:
+                duration: 2000
+                amplitude: 0.4
+                frequency: 8_058_947_261      # resonator frequency
+                if_frequency: 208_947_261    # difference in resonator frequency
+                shape: Rectangular()
+                type: ro                    # readout
+        5: # qubit id
+            RX:
+                duration: 40                # should be multiple of 4
+                amplitude: 0.5
+                frequency: 4_700_000_000    # qubit frequency
+                if_frequency: -200_000_000    # difference in qubit frequency
+                shape: Gaussian(5)
+                type: qd                    # qubit drive
+            MZ:
+                duration: 2000
+                amplitude: 0.2
+                frequency: 7_118_627_658      # resonator frequency
+                if_frequency: -136_372_342    # difference in resonator frequency
+                shape: Rectangular()
+                type: ro                    # readout
+
+    two_qubit:
+        3-2:
+            CZ:
+            - duration: 32
+              amplitude: -0.6025
+              shape: Exponential(12, 5000, 0.1)
+              qubit: 3
+              relative_start: 0
+              type: qf
+            - duration: 20
+              amplitude: 0
+              shape: Rectangular())
+              qubit: 3
+              relative_start: 32
+              type: qf
+            - type: virtual_z
+              phase: -3.630
+              qubit: 3
+
+            - duration: 32
+              amplitude: 0
+              shape: Rectangular())
+              qubit: 2
+              relative_start: 0
+              type: qf
+            - duration: 20
+              amplitude: 0
+              shape: Rectangular())
+              qubit: 2
+              relative_start: 32
+              type: qf
+            - type: virtual_z
+              phase: -0.041
+              qubit: 2
+
+        2-0:
+            CZ:
+            - duration: 28
+              amplitude: -0.142
+              shape: Exponential(12, 5000, 0.1)
+              qubit: 2
+              relative_start: 0
+              type: qf
+
+
+characterization:
+    single_qubit:
+        0:
+            readout_frequency: 7_212_299_307
+            drive_frequency: 5_050_304_836
+            anharmonicity: 291_463_266
+            T1: 5_857
+            T2: 0
+            state0_voltage: 0.0
+            state1_voltage: 0.0
+            mean_gnd_states: (-0.0+0.0j)
+            mean_exc_states: (0.0+0.0j)
+            sweetspot: 0.5507
+        1:
+            readout_frequency: 7_452_990_931
+            drive_frequency: 4_852_833_073
+            anharmonicity: 292_584_018
+            T1: 1_253
+            T2: 0
+            state0_voltage: 0.0
+            state1_voltage: 0.0
+            mean_gnd_states: (-0.0+0.0j)
+            mean_exc_states: (0.0+0.0j)
+            sweetspot: 0.2227
+        2:
+            readout_frequency: 7_655_083_068
+            drive_frequency: 5_795_371_914
+            anharmonicity: 276_187_576
+            T1: 4_563
+            T2: 0
+            state0_voltage: 0.0
+            state1_voltage: 0.0
+            mean_gnd_states: (-0.0+0.0j)
+            mean_exc_states: (0.0+0.0j)
+            sweetspot: -0.3780
+        3:
+            readout_frequency: 7_803_441_221
+            drive_frequency: 6_761_018_001
+            anharmonicity: 262_310_994
+            T1: 4_232
+            T2: 0
+            state0_voltage: 0.0
+            state1_voltage: 0.0
+            mean_gnd_states: (-0.0+0.0j)
+            mean_exc_states: (0.0+0.0j)
+            sweetspot: -0.8899
+        4:
+            readout_frequency: 8_058_947_261
+            drive_frequency: 6_586_543_060
+            anharmonicity: 261_390_626
+            T1: 492
+            T2: 0
+            state0_voltage: 0.0
+            state1_voltage: 0.0
+            mean_gnd_states: (-0.0+0.0j)
+            mean_exc_states: (0.0+0.0j)
+            sweetspot: 0.5890
+        5:
+            readout_frequency: 7_118_627_658
+            drive_frequency: 4_700_000_000
+            anharmonicity: 300_000_000
+            T1: 0
+            T2: 0
+            state0_voltage: 0.0
+            state1_voltage: 0.0
+            mean_gnd_states: (-0.0+0.0j)
+            mean_exc_states: (0.0+0.0j)
+            sweetspot: 0


### PR DESCRIPTION
This R works with latest version of qibocal and qblox drivers. The qw5_gold runcard is optimized for single qubit gates (also the qw5_gold_qblox.py contains some modifications that affects the single qubit performance). Please note that the q4 has a weird (but consistent) behaviour due to the chip itself, so no better performance can be reached.

Work with branches:
    qibolab: https://github.com/qiboteam/qibolab/tree/alvaro/autocalibration_qblox9_sweepers_refactor_ports
    qibocal: https://github.com/qiboteam/qibocal/tree/two-qubit-gates