### PR TITLE
Two qubit gates calibration for qw5q_gold

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
       - id: check-yaml
       - id: debug-statements
   - repo: https://github.com/psf/black
-    rev: 23.3.0
+    rev: 23.7.0
     hooks:
       - id: black
   - repo: https://github.com/pycqa/isort
@@ -18,6 +18,6 @@ repos:
       - id: isort
         args: ["--profile", "black"]
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.8.0
+    rev: v3.10.1
     hooks:
       - id: pyupgrade

--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
-# qibolab_platforms_qrc
+# QRC platforms
+This repository contains platforms that are currently available in the TII QRC Quantum Computing lab.
+
+In order to use these platforms, one needs to:
+
+1. Install the latest version of [qibolab](https://github.com/qiboteam/qibolab).
+2. Clone this repository
+```sh
+git clone https://github.com/qiboteam/qibolab_platforms_qrc
+```
+3. Point the environment variable `QIBOLAB_PLATFORMS` to the directory where `qibolab_platforms_qrc` was cloned. For example, if it was cloned in the home directory:
+```sh
+export QIBOLAB_PLATFORMS=~/qibolab_platforms_qrc
+```
+The last step needs to executed for every new terminal instance.
+To avoid having to do this, in linux you can add the above command to your `~/.bashrc`.
+Note that commands added to the `.bashrc` take effect from the next terminal instance, not the current.
+
+The `main` branch of this repository should contain the latest available platforms.
+If your platform is in a branch other than `main`, in addition to the above steps, you need to switch your local `qibolab_platforms_qrc` repository to your branch.
+If your platform works, you can open a pull request to merge it to main.

--- a/iqm5q.yml
+++ b/iqm5q.yml
@@ -1,10 +1,12 @@
 nqubits: 5
 description: IQM 5-qubit device, controlled with Zurich Instruments.
 
+#qubit 4 needs a lot of power for rabi and 4us T1 and T2 ???
+
 settings:
     nshots: 4096
     sampling_rate: 2.e+9
-    relaxation_time: 100_000
+    relaxation_time: 300_000
     time_of_flight: 280
     smearing: 0
     Fast_reset: False
@@ -19,16 +21,16 @@ native_gates:
         0: # qubit number
             RX:
                 duration: 40
-                amplitude: 0.606
-                frequency: 4095985280
-                shape: Gaussian(5)
+                amplitude: 0.634
+                frequency: 4_098_114_578
+                shape: Gaussian(5) #Drag(5, 0.01)
                 type: qd # qubit drive
                 start: 0
                 phase: 0
             MZ:
                 duration: 2000
-                amplitude: .1
-                frequency: 5_233_200_000
+                amplitude: .45
+                frequency: 5_230_200_000
                 shape: Rectangular()
                 type: ro # readout
                 start: 0
@@ -91,16 +93,16 @@ native_gates:
         4: # qubit number
             RX:
                 duration: 40
-                amplitude: 0.6272
-                frequency: 4102039843
+                amplitude: 0.55
+                frequency: 4.24704e+9 #4.1017e+9
                 shape: Gaussian(5)
                 type: qd # qubit drive
                 start: 0
                 phase: 0
             MZ:
                 duration: 2000
-                amplitude: .1
-                frequency: 5.5240e+9
+                amplitude: .55
+                frequency: 5.5180e+9
                 shape: Rectangular()
                 type: ro # readout
                 start: 0
@@ -127,9 +129,13 @@ native_gates:
 characterization:
     single_qubit:
         0:
-            readout_frequency: 5_228_700_000
+            readout_frequency: 5_230_200_000
             resonator_polycoef_flux: []
-            drive_frequency: 4095985280
+            drive_frequency: 4_098_114_578 #4_098_014_578
+            anharmonicity: 217_492_000
+            Ec: 0
+            Ej: 0
+            g: 0
             T1: 0.0
             T2: 0.0
             sweetspot: 0
@@ -137,13 +143,16 @@ characterization:
             mean_gnd_states: 1.5417+0.1817j
             mean_exc_states: 2.5332-0.5914j
             # parameters for single shot classification
-            threshold: 1.5939
-            iq_angle: 0.662
-            alpha: 217_492_000
+            threshold: 1.5435
+            iq_angle:  2.602
         1:
             readout_frequency: 4.9525e+9
             resonator_polycoef_flux: []
             drive_frequency: 4.25e+9
+            anharmonicity: 0
+            # Ec: 0
+            # Ej: 0
+            # g: 0
             T1: 0.0
             T2: 0.0
             sweetspot: 0
@@ -154,6 +163,10 @@ characterization:
             readout_frequency: 6.109e+9
             resonator_polycoef_flux: []
             drive_frequency: 4342116873
+            anharmonicity: 211_604_296
+            # Ec: 0
+            # Ej: 0
+            # g: 0
             T1: 0.0
             T2: 0.0
             sweetspot: -0.1745
@@ -163,11 +176,14 @@ characterization:
             # parameters for single shot classification
             threshold: -0.6085
             iq_angle: -0.474
-            alpha: 211_604_296
         3:
             readout_frequency: 5.8060e+9
             resonator_polycoef_flux: []
             drive_frequency: 4130512577
+            anharmonicity: 214_000_000
+            # Ec: 0
+            # Ej: 0
+            # g: 0
             T1: 0.0
             T2: 0.0
             sweetspot: 0.0
@@ -177,11 +193,14 @@ characterization:
             # parameters for single shot classificatio
             threshold: 0.1074
             iq_angle: -2.904
-            alpha: 214_000_000
         4:
-            readout_frequency: 5.5240e+9
+            readout_frequency: 5.5180e+9 #5.5240e+9
             resonator_polycoef_flux: []
-            drive_frequency: 4.1017e+9
+            drive_frequency: 4.24704e+9 #4.1017e+9
+            anharmonicity: 0
+            # Ec: 0
+            # Ej: 0
+            # g: 0
             T1: 0.0
             T2: 0.0
             sweetspot: 0
@@ -191,7 +210,6 @@ characterization:
             # parameters for single shot classification
             threshold: 0.233806
             iq_angle: 0.481
-            alpha: 0
         "c0":
             sweetspot: 0.0
             # filter: {}

--- a/iqm5q_q0.py
+++ b/iqm5q_q0.py
@@ -7,7 +7,7 @@ from qibolab.instruments.erasynth import ERA
 from qibolab.instruments.oscillator import LocalOscillator
 from qibolab.instruments.zhinst import Zurich
 
-RUNCARD = pathlib.Path(__file__).parent / "iqm5q.yml"
+RUNCARD = pathlib.Path(__file__).parent / "iqm5q_q0.yml"
 
 TWPA_ADDRESS = "192.168.0.210"
 
@@ -23,13 +23,12 @@ def create(runcard=RUNCARD):
         "SHFQC": [{"address": "DEV12146", "uid": "device_shfqc"}],
         "HDAWG": [
             {"address": "DEV8660", "uid": "device_hdawg"},
-            {"address": "DEV8673", "uid": "device_hdawg2"},
         ],
         "PQSC": [{"address": "DEV10055", "uid": "device_pqsc"}],
     }
 
     shfqc = []
-    for i in range(5):
+    for i in range(1):
         shfqc.append(
             {"iq_signal": f"q{i}/drive_line", "ports": f"SGCHANNELS/{i}/OUTPUT"}
         )
@@ -41,16 +40,11 @@ def create(runcard=RUNCARD):
         )
 
     hdawg = []
-    for i in range(5):
+    for i in range(1):
         hdawg.append({"rf_signal": f"q{i}/flux_line", "ports": f"SIGOUTS/{i}"})
-    for c, i in zip(itertools.chain(range(0, 2), range(3, 4)), range(5, 8)):
-        hdawg.append({"rf_signal": f"qc{c}/flux_line", "ports": f"SIGOUTS/{i}"})
-
-    hdawg2 = [{"rf_signal": "qc4/flux_line", "ports": f"SIGOUTS/0"}]
 
     pqsc = [
         "internal_clock_signal",
-        {"to": "device_hdawg2", "port": "ZSYNCS/4"},
         {"to": "device_hdawg", "port": "ZSYNCS/2"},
         {"to": "device_shfqc", "port": "ZSYNCS/0"},
     ]
@@ -58,7 +52,6 @@ def create(runcard=RUNCARD):
     connections = {
         "device_shfqc": shfqc,
         "device_hdawg": hdawg,
-        "device_hdawg2": hdawg2,
         "device_pqsc": pqsc,
     }
 
@@ -72,7 +65,7 @@ def create(runcard=RUNCARD):
         descriptor,
         use_emulation=False,
         time_of_flight=75,
-        smearing=50,  # time_of_flight=280, smearing=100
+        smearing=80,
     )
 
     # Create channel objects and map controllers
@@ -90,19 +83,13 @@ def create(runcard=RUNCARD):
         Channel(
             f"L4-{i}", port=controller[("device_shfqc", f"SGCHANNELS/{i-5}/OUTPUT")]
         )
-        for i in range(15, 20)
+        for i in range(15, 16)
     )
     # flux qubits (CAREFUL WITH THIS !!!)
     channels |= (
         Channel(f"L4-{i}", port=controller[("device_hdawg", f"SIGOUTS/{i-6}")])
-        for i in range(6, 11)
+        for i in range(6, 7)
     )
-    # flux couplers
-    channels |= (
-        Channel(f"L4-{i}", port=controller[("device_hdawg", f"SIGOUTS/{i-11+5}")])
-        for i in range(11, 14)
-    )
-    channels |= Channel("L4-14", port=controller[("device_hdawg2", f"SIGOUTS/0")])
 
     # TWPA pump(EraSynth)
     channels |= Channel("L3-32")
@@ -116,19 +103,15 @@ def create(runcard=RUNCARD):
     # readout
     channels["L2-7"].power_range = -25
     # drive
-    for i in range(5, 10):
+    for i in range(5, 6):
         channels[f"L4-1{i}"].power_range = -10
-    channels[f"L4-19"].power_range = 0
 
     # HDAWGS
     # Sets the output voltage range.
     # The instrument selects the next higher available Range with a resolution of 0.4 Volts.
 
     # flux
-    for i in range(6, 11):
-        channels[f"L4-{i}"].power_range = 0.8
-    # flux couplers
-    for i in range(11, 15):
+    for i in range(6, 7):
         channels[f"L4-{i}"].power_range = 0.8
 
     # Instantiate local oscillators
@@ -145,18 +128,12 @@ def create(runcard=RUNCARD):
     # Set Dummy LO parameters (Map only the two by two oscillators)
     local_oscillators[0].frequency = 5_500_000_000  # For SG0 (Readout)
     local_oscillators[1].frequency = 4_200_000_000  # For SG1 and SG2 (Drive)
-    local_oscillators[2].frequency = 4_600_000_000  # For SG3 and SG4 (Drive)
-    local_oscillators[3].frequency = 4_800_000_000  # For SG5 and SG6 (Drive)
 
     # Map LOs to channels
     ch_to_lo = {
         "L2-7": 0,
         "L4-15": 1,
-        "L4-16": 1,
-        "L4-17": 2,
-        "L4-18": 2,
-        "L4-19": 3,
-        "L3-32": 4,
+        "L3-32": 2,
     }
     for ch, lo in ch_to_lo.items():
         channels[ch].local_oscillator = local_oscillators[lo]
@@ -167,26 +144,13 @@ def create(runcard=RUNCARD):
 
     # assign channels to qubits and sweetspots(operating points)
     qubits = platform.qubits
-    for q in range(0, 5):
+    for q in range(0, 1):
         qubits[q].feedback = channels["L3-31"]
         qubits[q].readout = channels["L2-7"]
 
-    for q in range(0, 5):
+    for q in range(0, 1):
         qubits[q].drive = channels[f"L4-{15 + q}"]
         qubits[q].flux = channels[f"L4-{6 + q}"]
         channels[f"L4-{6 + q}"].qubit = qubits[q]
-
-    # assign channels to couplers and sweetspots(operating points)
-    for c in range(0, 2):
-        qubits[f"c{c}"].flux = channels[f"L4-{11 + c}"]
-        channels[f"L4-{11 + c}"].qubit = qubits[f"c{c}"]
-    for c in range(3, 5):
-        qubits[f"c{c}"].flux = channels[f"L4-{10 + c}"]
-        channels[f"L4-{10 + c}"].qubit = qubits[f"c{c}"]
-
-    # assign qubits to couplers
-    for c in itertools.chain(range(0, 2), range(3, 5)):
-        qubits[f"c{c}"].flux_coupler = [qubits[c]]
-        qubits[f"c{c}"].flux_coupler.append(qubits[2])
 
     return platform

--- a/iqm5q_q0.yml
+++ b/iqm5q_q0.yml
@@ -1,0 +1,51 @@
+nqubits: 1
+description: IQM 5-qubit device q0, controlled with Zurich Instruments.
+
+settings:
+    nshots: 4096
+    sampling_rate: 2.e+9
+    relaxation_time: 300_000
+    time_of_flight: 80
+    smearing: 80
+    Fast_reset: False
+    chip: iqm5q_q0
+
+qubits: [0]
+
+topology: []
+
+native_gates:
+    single_qubit:
+        0: # qubit number
+            RX:
+                duration: 40
+                amplitude: 0.634
+                frequency: 4_098_114_578
+                shape: Gaussian(5) #Drag(5, 0.01)
+                type: qd # qubit drive
+                start: 0
+                phase: 0
+            MZ:
+                duration: 2000
+                amplitude: .45
+                frequency: 5_230_200_000
+                shape: Rectangular()
+                type: ro # readout
+                start: 0
+                phase: 0
+
+characterization:
+    single_qubit:
+        0:
+            readout_frequency: 5_230_200_000
+            resonator_polycoef_flux: []
+            drive_frequency: 4_098_114_578
+            T1: 0.0
+            T2: 0.0
+            sweetspot: 0
+            mean_gnd_states: 1.5417+0.1817j
+            mean_exc_states: 2.5332-0.5914j
+            # parameters for single shot classification
+            threshold: 1.5435
+            iq_angle:  2.602
+            anharmonicity: 217_492_000

--- a/qw25q.yml
+++ b/qw25q.yml
@@ -414,6 +414,10 @@ characterization:
         A1:
             readout_frequency: 6886009383
             drive_frequency: 5.06217e+9
+            anharmonicity: 0
+            Ec: 0
+            Ej: 0
+            g: 0
             T1: 0.0
             T2: 0.0
             sweetspot: 0.0
@@ -429,6 +433,10 @@ characterization:
         A2:
             readout_frequency: 7267518645
             drive_frequency: 5.8513e+9
+            anharmonicity: 0
+            Ec: 0
+            Ej: 0
+            g: 0
             T1: 0.0
             T2: 0.0
             sweetspot: 0.05
@@ -444,6 +452,10 @@ characterization:
         A3:
             readout_frequency: 7.5213366e+9
             drive_frequency: 5.991311e+9
+            anharmonicity: 0
+            Ec: 0
+            Ej: 0
+            g: 0
             T1: 0.0
             T2: 0.0
             sweetspot: 0.0
@@ -459,6 +471,10 @@ characterization:
         A4:
             readout_frequency: 7119206723
             drive_frequency: 5.239805e+9
+            anharmonicity: 0
+            Ec: 0
+            Ej: 0
+            g: 0
             T1: 0.0
             T2: 0.0
             sweetspot: 0.0
@@ -474,6 +490,10 @@ characterization:
         A5:
             readout_frequency: 7.692063E+09
             drive_frequency: 6081000000
+            anharmonicity: 0
+            Ec: 0
+            Ej: 0
+            g: 0
             T1: 0.0
             T2: 0.0
             sweetspot: 0.0
@@ -489,6 +509,10 @@ characterization:
         A6:
             readout_frequency: 7942098387
             drive_frequency: 6.860000E+09
+            anharmonicity: 0
+            Ec: 0
+            Ej: 0
+            g: 0
             T1: 0.0
             T2: 0.0
             sweetspot: 0.0
@@ -504,6 +528,10 @@ characterization:
         B1:
             readout_frequency: 6.927829E+09
             drive_frequency: 5.057380E+09
+            anharmonicity: 0
+            Ec: 0
+            Ej: 0
+            g: 0
             T1: 0.0
             T2: 0.0
             sweetspot: 0.0
@@ -519,6 +547,10 @@ characterization:
         B2:
             readout_frequency: 7.138028E+09
             drive_frequency: 6.017959E+09
+            anharmonicity: 0
+            Ec: 0
+            Ej: 0
+            g: 0
             T1: 0.0
             T2: 0.0
             sweetspot: 0.0
@@ -534,6 +566,10 @@ characterization:
         B3:
             readout_frequency: 7.343333E+09
             drive_frequency: 6.058000E+09
+            anharmonicity: 0
+            Ec: 0
+            Ej: 0
+            g: 0
             T1: 0.0
             T2: 0.0
             sweetspot: 0.0
@@ -549,6 +585,10 @@ characterization:
         B4:
             readout_frequency: 7.748361E+09
             drive_frequency: 6.120616E+09
+            anharmonicity: 0
+            Ec: 0
+            Ej: 0
+            g: 0
             T1: 0.0
             T2: 0.0
             sweetspot: 0.0
@@ -564,6 +604,10 @@ characterization:
         B5:
             readout_frequency: 7.599758E+09
             drive_frequency: 6.101000E+09
+            anharmonicity: 0
+            Ec: 0
+            Ej: 0
+            g: 0
             T1: 0.0
             T2: 0.0
             sweetspot: 0.0
@@ -579,6 +623,10 @@ characterization:
         C1:
             readout_frequency: 7.061090E+09
             drive_frequency: 5.405000E+09
+            anharmonicity: 0
+            Ec: 0
+            Ej: 0
+            g: 0
             T1: 0.0
             T2: 0.0
             sweetspot: 0.0
@@ -594,6 +642,10 @@ characterization:
         C2:
             readout_frequency: 7.460670E+09
             drive_frequency: 6.084000E+09
+            anharmonicity: 0
+            Ec: 0
+            Ej: 0
+            g: 0
             T1: 0.0
             T2: 0.0
             sweetspot: 0.0
@@ -609,6 +661,10 @@ characterization:
         C3:
             readout_frequency: 7.627060E+09
             drive_frequency: 5.803000E+09
+            anharmonicity: 0
+            Ec: 0
+            Ej: 0
+            g: 0
             T1: 0.0
             T2: 0.0
             sweetspot: 0.0
@@ -624,6 +680,10 @@ characterization:
         C4:
             readout_frequency: 7.220770E+09
             drive_frequency: 5.388000E+09
+            anharmonicity: 0
+            Ec: 0
+            Ej: 0
+            g: 0
             T1: 0.0
             T2: 0.0
             sweetspot: 0.0
@@ -639,6 +699,10 @@ characterization:
         C5:
             readout_frequency: 7.830770E+09
             drive_frequency: 5.822600E+09
+            anharmonicity: 0
+            Ec: 0
+            Ej: 0
+            g: 0
             T1: 0.0
             T2: 0.0
             sweetspot: 0.0
@@ -654,6 +718,10 @@ characterization:
         D1:
             readout_frequency: 6.952000E+09
             drive_frequency: 4.967000E+09
+            anharmonicity: 0
+            Ec: 0
+            Ej: 0
+            g: 0
             T1: 0.0
             T2: 0.0
             sweetspot: 0.0
@@ -669,6 +737,10 @@ characterization:
         D2:
             readout_frequency: 7.111110E+09
             drive_frequency: 5.746000E+09
+            anharmonicity: 0
+            Ec: 0
+            Ej: 0
+            g: 0
             T1: 0.0
             T2: 0.0
             sweetspot: 0.0
@@ -684,6 +756,10 @@ characterization:
         D3:
             readout_frequency: 7.342070E+09
             drive_frequency: 6.036000E+09
+            anharmonicity: 0
+            Ec: 0
+            Ej: 0
+            g: 0
             T1: 0.0
             T2: 0.0
             sweetspot: 0.0
@@ -698,6 +774,10 @@ characterization:
         D4:
             readout_frequency: 7.800000E+09
             drive_frequency: 6.552000E+09
+            anharmonicity: 0
+            Ec: 0
+            Ej: 0
+            g: 0
             T1: 0.0
             T2: 0.0
             sweetspot: 0.0
@@ -712,6 +792,10 @@ characterization:
         D5:
             readout_frequency: 7.459960E+09
             drive_frequency: 5.983000E+09
+            anharmonicity: 0
+            Ec: 0
+            Ej: 0
+            g: 0
             T1: 0.0
             T2: 0.0
             sweetspot: 0.0

--- a/qw5q_gold.yml
+++ b/qw5q_gold.yml
@@ -11,29 +11,29 @@ resonator_type: 2D
 native_gates:
     single_qubit:
         0:
-            RX: {duration: 40, amplitude: 0.5037576688262035, frequency: 5050222356,
+            RX: {duration: 40, amplitude: 0.5088805673637675, frequency: 5049151777,
                 shape: 'Drag(5, 0.200)', type: qd, start: 0, phase: 0}
-            MZ: {duration: 2000, amplitude: 0.1, frequency: 7212301152, shape: Rectangular(),
+            MZ: {duration: 2000, amplitude: 0.1, frequency: 7211551152, shape: Rectangular(),
                 type: ro, start: 0, phase: 0}
         1:
-            RX: {duration: 40, amplitude: 0.5091870515531648, frequency: 4851448063,
+            RX: {duration: 40, amplitude: 0.5127643052160186, frequency: 4850198151,
                 shape: 'Drag(5, 0.000)', type: qd}
-            MZ: {duration: 2000, amplitude: 0.2, frequency: 7453011071, shape: Rectangular(),
+            MZ: {duration: 2000, amplitude: 0.2, frequency: 7452511071, shape: Rectangular(),
                 type: ro}
         2:
-            RX: {duration: 40, amplitude: 0.4961740399301971, frequency: 5796025841,
+            RX: {duration: 40, amplitude: 0.5017192729158884, frequency: 5794496812,
                 shape: 'Drag(5, -0.100)', type: qd}
-            MZ: {duration: 2000, amplitude: 0.25, frequency: 7655058484, shape: Rectangular(),
+            MZ: {duration: 2000, amplitude: 0.25, frequency: 7654808484, shape: Rectangular(),
                 type: ro}
         3:
-            RX: {duration: 40, amplitude: 0.4977305637146838, frequency: 6759863862,
+            RX: {duration: 40, amplitude: 0.5012372550152853, frequency: 6760504418,
                 shape: 'Drag(5, 0.300)', type: qd}
-            MZ: {duration: 2000, amplitude: 0.2, frequency: 7803438073, shape: Rectangular(),
+            MZ: {duration: 2000, amplitude: 0.2, frequency: 7802688073, shape: Rectangular(),
                 type: ro}
         4:
-            RX: {duration: 40, amplitude: 0.56468497579218, frequency: 6590262523,
+            RX: {duration: 40, amplitude: 0.5652737353449859, frequency: 6590544857,
                 shape: 'Drag(5, -0.100)', type: qd}
-            MZ: {duration: 2000, amplitude: 0.4, frequency: 8058917834, shape: Rectangular(),
+            MZ: {duration: 2000, amplitude: 0.4, frequency: 8058417834, shape: Rectangular(),
                 type: ro}
         5:
             RX: {duration: 40, amplitude: 0.5, frequency: 4700000000, shape: Gaussian(5),
@@ -47,40 +47,18 @@ native_gates:
                 qubit: 2, relative_start: 0, type: qf}
         1-2:
             CZ:
-            - duration: 32
-              amplitude: 0.1679 # +0.16
-              shape: Exponential(2, 5000, 0.1)
-              qubit: 2
-              relative_start: 0
-              type: qf
-            - type: virtual_z
-              phase: -3.239
-              qubit: 1
-            - type: virtual_z
-              phase: -0.1722
-              qubit: 2
-            - duration: 72
-              amplitude: -0.5544 # +0.16
-              shape: Exponential(12, 5000, 0.1)
-              qubit: 0
-              relative_start: 0
-              type: qf
-
+            - {duration: 20, amplitude: 0.186, shape: 'Exponential(2, 5000, 0.1)',
+                qubit: 2, relative_start: 0, type: qf}
+            - {type: virtual_z, phase: -3.239, qubit: 1}
+            - {type: virtual_z, phase: -0.1722, qubit: 2}
+            - {duration: 72, amplitude: -0.58, shape: 'Exponential(12, 5000, 0.1)',
+                qubit: 0, relative_start: 0, type: qf}
         3-2:
             CZ:
-            - duration: 32
-              amplitude: 0.559186 # 563
-              shape: Exponential(12, 5000, 0.1)
-              qubit: 3
-              relative_start: 0
-              type: qf
-            - type: virtual_z
-              phase: -5.6326
-              qubit: 2
-            - type: virtual_z
-              phase: -1.6398
-              qubit: 3
-
+            - {duration: 32, amplitude: 0.622, shape: 'Exponential(12, 5000, 0.1)',
+                qubit: 3, relative_start: 0, type: qf}
+            - {type: virtual_z, phase: -5.6326, qubit: 2}
+            - {type: virtual_z, phase: -1.6398, qubit: 3}
         4-2:
             CZ:
             - {duration: 40, amplitude: -0.1355, shape: 'Exponential(10, 3000, 0.05)',
@@ -88,90 +66,83 @@ native_gates:
 characterization:
     single_qubit:
         0:
-            readout_frequency: 7_212_362_551
-            drive_frequency: 5_045_070_000
-            anharmonicity: 291_463_266
-            Ec: 270_000_000
-            Ej: 11_400_000_000
-            g: 107_000_000
-            T1: 5_857
+            readout_frequency: 7211551152
+            drive_frequency: 5049151777
+            anharmonicity: 291463266
+            Ec: 270000000
+            Ej: 11400000000
+            g: 107000000
+            T1: 5857
             T2: 0
-            sweetspot: 0.5944
-            iq_angle: 1.87610809139229
-            threshold: 0.00509979815633151
-            pi_pulse_amplitude: 0.5037576688262035
-            mean_gnd_states: [-0.0016882175134342939, -0.003335126586841177]
-            mean_exc_states: [-0.0026015215779867555, -0.006232978138739619]
+            sweetspot: 0.5825
+            iq_angle: -1.1924147272943912
+            threshold: -0.0021557394780600207
+            pi_pulse_amplitude: 0.5088805673637675
+            mean_gnd_states: [0.0024128846139167075, -0.005052254548492374]
+            mean_exc_states: [0.0036847079207207025, -0.001852999647180155]
         1:
-            readout_frequency: 7_453_149_599
-            drive_frequency: 4_852_280_321
-            anharmonicity: 292_584_018
-            Ec: 270_000_000
-            Ej: 11_400_000_000
-            g: 114_000_000
-            T1: 1_253
+            readout_frequency: 7452511071
+            drive_frequency: 4850198151
+            anharmonicity: 292584018
+            Ec: 270000000
+            Ej: 11400000000
+            g: 114000000
+            T1: 1253
             T2: 0
-            sweetspot: 0.2844
-            iq_angle: 2.6915241733351234
-            threshold: 0.004502589232760579
-            pi_pulse_amplitude: 0.5091870515531648
-            mean_gnd_states: [-0.002494220030668187, -0.0005834222804035717]
-            mean_exc_states: [-0.0058959609760896705, -0.00222693779514737]
+            sweetspot: 0.259
+            iq_angle: 2.022337628465806
+            threshold: -0.0007914653318098342
+            pi_pulse_amplitude: 0.5127643052160186
+            mean_gnd_states: [-0.0018382030529094067, 0.003643860913498073]
+            mean_exc_states: [-0.003789544870881507, -0.00037987740570550395]
         2:
-            readout_frequency: 7_655_110_446
-            drive_frequency: 5_794_176_000
-            anharmonicity: 276_187_576
-            Ec: 270_000_000
-            Ej: 16_000_000_000
-            g: 83_600_000
-            T1: 4_563
+            readout_frequency: 7654808484
+            drive_frequency: 5794496812
+            anharmonicity: 276187576
+            Ec: 270000000
+            Ej: 16000000000
+            g: 83600000
+            T1: 4563
             T2: 0
-            sweetspot: -0.3562
-            iq_angle: 2.8523650124575743
-            threshold: 0.0028302188032929727
-            pi_pulse_amplitude: 0.4961740399301971
-            mean_gnd_states: [-0.0014952193335097431, -0.00010921406835205993]
-            mean_exc_states: [-0.0040435979524575255, -0.0008675397897668674]
+            sweetspot: -0.37
+            iq_angle: 1.8678749919643882
+            threshold: 0.0013984324433131425
+            pi_pulse_amplitude: 0.5017192729158884
+            mean_gnd_states: [-0.00155759015352752, 0.0004936294708889704]
+            mean_exc_states: [-0.0023438796040445367, -0.002074783441978098]
         3:
-            readout_frequency: 7_803_377_426
-            drive_frequency: 6_760_050_000
-            anharmonicity: 262_310_994
-            Ec: 270_000_000
-            Ej: 21_200_000_000
-            g: 54_300_000
-            T1: 4_232
+            readout_frequency: 7802688073
+            drive_frequency: 6760504418
+            anharmonicity: 262310994
+            Ec: 270000000
+            Ej: 21200000000
+            g: 54300000
+            T1: 4232
             T2: 0
-            sweetspot: -0.74
-            iq_angle: 1.8964467227666972
-            threshold: 0.004028533776763
-            pi_pulse_amplitude: 0.4977305637146838
-            mean_gnd_states: [-0.0015922092755997937, -0.0019741712126146666]
-            mean_exc_states: [-0.002783012296958964, -0.005500677651576833]
+            sweetspot: -0.77
+            iq_angle: -0.9179883441132042
+            threshold: -0.003336112990282053
+            pi_pulse_amplitude: 0.5012372550152853
+            mean_gnd_states: [-0.0009084138309619769, -0.00606513745555827]
+            mean_exc_states: [0.0018613247855092819, -0.002442881456772784]
         4:
-            readout_frequency: 8_058_739_833
-            drive_frequency: 6_585_145_857
-            anharmonicity: 261_390_626
-            Ec: 270_000_000
-            Ej: 21_200_000_000
-            g: 62_700_000
+            readout_frequency: 8058417834
+            drive_frequency: 6590544857
+            anharmonicity: 261390626
+            Ec: 270000000
+            Ej: 21200000000
+            g: 62700000
             T1: 492
             T2: 0
             state0_voltage: 0.0
             state1_voltage: 0.0
-            mean_gnd_states: (-0.0+0.0j)
-            mean_exc_states: (0.0+0.0j)
-            sweetspot: 0.4555
-        5:
-            readout_frequency: 7_118_627_416
-            drive_frequency: 4_700_000_000
-            anharmonicity: 300_000_000
-            Ec: 270_000_000
-            Ej: 11_400_000_000
-            g: 77_600_000
-            T1: 0
-            T2: 0
-            state0_voltage: 0.0
-            state1_voltage: 0.0
-            mean_gnd_states: (-0.0+0.0j)
-            mean_exc_states: (0.0+0.0j)
-            sweetspot: 0
+            mean_gnd_states: [0.002209274009560061, 0.0015765070432509634]
+            mean_exc_states: [-0.0006520848599576615, 0.0013895642081229985]
+            sweetspot: 0.64
+            pi_pulse_amplitude: 0.5652737353449859
+            threshold: -0.000801296142501799
+            iq_angle: 3.0763517887784317
+        5: {readout_frequency: 7118627416, drive_frequency: 4700000000, anharmonicity: 300000000,
+            Ec: 270000000, Ej: 11400000000, g: 77600000, T1: 0, T2: 0, state0_voltage: 0.0,
+            state1_voltage: 0.0, mean_gnd_states: (-0.0+0.0j), mean_exc_states: (0.0+0.0j),
+            sweetspot: 0}

--- a/qw5q_gold.yml
+++ b/qw5q_gold.yml
@@ -68,17 +68,17 @@ native_gates:
 
         3-2:
             CZ:
-            - duration: 32
-              amplitude: +0.6038 # +0.8 #
+            - duration: 30
+              amplitude: +0.5803 # +0.8 #
               shape: Exponential(12, 5000, 0.1)
               qubit: 3
               relative_start: 0
               type: qf
             - type: virtual_z
-              phase: 0.14
+              phase: -0.1204
               qubit: 2
             - type: virtual_z
-              phase: 2.48
+              phase: -5.57
               qubit: 3
 
         4-2:

--- a/qw5q_gold.yml
+++ b/qw5q_gold.yml
@@ -124,6 +124,12 @@ native_gates:
               qubit: 3
               relative_start: 0
               type: qf
+            - type: virtual_z
+              phase: -0.175
+              qubit: 2
+            - type: virtual_z
+              phase: -0.86
+              qubit: 3
 
         4-2:
             CZ:
@@ -139,12 +145,12 @@ characterization:
     single_qubit:
         0:
             readout_frequency: 7_212_301_152 #7_212_299_307
-            bare_resonator_frequency: 7_200_000_000            
+            bare_resonator_frequency: 7_200_000_000
             drive_frequency: 5_050_351_004
             anharmonicity: 291_463_266
             Ec: 270_000_000
             Ej: 11_400_000_000
-            g: 107_000_000            
+            g: 107_000_000
             T1: 5_857
             T2: 0
             sweetspot: 0.5544
@@ -155,12 +161,12 @@ characterization:
 
         1:
             readout_frequency: 7_453_011_071 #7_452_990_931
-            bare_resonator_frequency: 7_400_000_000            
+            bare_resonator_frequency: 7_400_000_000
             drive_frequency: 4_852_342_447
             anharmonicity: 292_584_018
             Ec: 270_000_000
             Ej: 11_400_000_000
-            g: 114_000_00 
+            g: 114_000_00
             T1: 1_253
             T2: 0
             sweetspot: 0.2244
@@ -175,7 +181,7 @@ characterization:
             anharmonicity: 276_187_576
             Ec: 270_000_000
             Ej: 16_000_000_000
-            g: 83_600_000              
+            g: 83_600_000
             T1: 4_563
             T2: 0
             sweetspot: -0.3762
@@ -190,7 +196,7 @@ characterization:
             anharmonicity: 262_310_994
             Ec: 270_000_000
             Ej: 21_200_000_000
-            g: 54_300_000             
+            g: 54_300_000
             T1: 4_232
             T2: 0
             sweetspot: -0.8893
@@ -205,7 +211,7 @@ characterization:
             anharmonicity: 261_390_626
             Ec: 270_000_000
             Ej: 21_200_000_000
-            g: 62_700_000             
+            g: 62_700_000
             T1: 492
             T2: 0
             sweetspot: 0.5915
@@ -220,7 +226,7 @@ characterization:
             anharmonicity: 300_000_000
             Ec: 270_000_000
             Ej: 11_400_000_000
-            g: 77_600_000            
+            g: 77_600_000
             T1: 0
             T2: 0
             sweetspot: 0

--- a/qw5q_gold.yml
+++ b/qw5q_gold.yml
@@ -1,112 +1,50 @@
 nqubits: 5
 description: QuantWare 5-qubit device at XLD fridge.
-
-settings:
-    nshots: 1024
-    sampling_rate: 1_000_000_000
-    relaxation_time: 20_000
-
+settings: {nshots: 1024, sampling_rate: 1000000000, relaxation_time: 20000}
 qubits: [0, 1, 2, 3, 4, 5]
-
-topology: [[0, 2], [1, 2], [2, 3], [2, 4]]
-
+topology:
+- [0, 2]
+- [1, 2]
+- [2, 3]
+- [2, 4]
 resonator_type: 2D
-
-
 native_gates:
     single_qubit:
-        0: # qubit id
-            RX:
-                duration: 40                   # should be multiple of 4
-                amplitude: 0.5028
-                frequency: 5_049_993_576 #5_050_351_004    # qubit frequency
-                shape: Drag(5, 0.200) #Gaussian(5)
-                type: qd                    # qubit drive
-                start: 0
-                phase: 0
-            MZ:
-                duration: 2000
-                amplitude: 0.1
-                frequency: 7_212_301_152 #7_212_299_307     # resonator frequency
-                shape: Rectangular()
-                type: ro                    # readout
-                start: 0
-                phase: 0
-        1: # qubit id
-            RX:
-                duration: 40                  # should be multiple of 4
-                amplitude: 0.5078
-                frequency: 4_852_156_977 #4_852_342_447    # qubit frequency
-                shape: Drag(5, 0.000) #Gaussian(5)
-                type: qd                    # qubit drive
-            MZ:
-                duration: 2000
-                amplitude: 0.2
-                frequency: 7_453_011_071 #7_452_990_931    # resonator frequency
-                shape: Rectangular()
-                type: ro                    # readout
-        2: # qubit id
-            RX:
-                duration: 40                   # should be multiple of 4
-                amplitude: 0.5016
-                frequency: 5_795_984_267 #5_796_172_783   # qubit frequency
-                shape: Drag(5, -0.100) #Gaussian(5)
-                type: qd                    # qubit drive
-            MZ:
-                duration: 2000
-                amplitude: 0.25
-                frequency: 7_655_058_484 #7_655_083_068    # resonator frequency
-                shape: Rectangular()
-                type: ro                    # readout
-        3: # qubit id
-            RX:
-                duration: 40                   # should be multiple of 4
-                amplitude: 0.5026
-                frequency: 6_760_862_966 #6_760_966_895    # qubit frequency
-                shape: Drag(5, 0.300) #Gaussian(5)
-                type: qd                    # qubit drive
-            MZ:
-                duration: 2000
-                amplitude: 0.2
-                frequency: 7_803_438_073 #7_803_441_221    # resonator frequency
-                shape: Rectangular()
-                type: ro                    # readout
-        4: # qubit id
-            RX:
-                duration: 40                # should be multiple of 4
-                amplitude: 0.4536           #0.5172
-                frequency: 6_590_650_923    # qubit frequency
-                shape: Drag(5, -0.100) #Gaussian(5)
-                type: qd                    # qubit drive
-            MZ:
-                duration: 2000
-                amplitude: 0.4
-                frequency: 8_058_917_834 #8_058_947_261      # resonator frequency
-                shape: Rectangular()
-                type: ro                    # readout
-        5: # qubit id
-            RX:
-                duration: 40                # should be multiple of 4
-                amplitude: 0.5
-                frequency: 4_700_000_000    # qubit frequency
-                shape: Gaussian(5)
-                type: qd                    # qubit drive
-            MZ:
-                duration: 2000
-                amplitude: 0.2
-                frequency: 7_118_627_658      # resonator frequency
-                shape: Rectangular()
-                type: ro                    # readout
-
+        0:
+            RX: {duration: 40, amplitude: 0.5037576688262035, frequency: 5050222356,
+                shape: 'Drag(5, 0.200)', type: qd, start: 0, phase: 0}
+            MZ: {duration: 2000, amplitude: 0.1, frequency: 7212301152, shape: Rectangular(),
+                type: ro, start: 0, phase: 0}
+        1:
+            RX: {duration: 40, amplitude: 0.5091870515531648, frequency: 4851448063,
+                shape: 'Drag(5, 0.000)', type: qd}
+            MZ: {duration: 2000, amplitude: 0.2, frequency: 7453011071, shape: Rectangular(),
+                type: ro}
+        2:
+            RX: {duration: 40, amplitude: 0.4961740399301971, frequency: 5796025841,
+                shape: 'Drag(5, -0.100)', type: qd}
+            MZ: {duration: 2000, amplitude: 0.25, frequency: 7655058484, shape: Rectangular(),
+                type: ro}
+        3:
+            RX: {duration: 40, amplitude: 0.4977305637146838, frequency: 6759863862,
+                shape: 'Drag(5, 0.300)', type: qd}
+            MZ: {duration: 2000, amplitude: 0.2, frequency: 7803438073, shape: Rectangular(),
+                type: ro}
+        4:
+            RX: {duration: 40, amplitude: 0.56468497579218, frequency: 6590262523,
+                shape: 'Drag(5, -0.100)', type: qd}
+            MZ: {duration: 2000, amplitude: 0.4, frequency: 8058917834, shape: Rectangular(),
+                type: ro}
+        5:
+            RX: {duration: 40, amplitude: 0.5, frequency: 4700000000, shape: Gaussian(5),
+                type: qd}
+            MZ: {duration: 2000, amplitude: 0.2, frequency: 7118627658, shape: Rectangular(),
+                type: ro}
     two_qubit:
         0-2:
             CZ:
-            - duration: 40
-              amplitude: +0.142
-              shape: Exponential(12, 5000, 0.1)
-              qubit: 2
-              relative_start: 0
-              type: qf
+            - {duration: 40, amplitude: 0.142, shape: 'Exponential(12, 5000, 0.1)',
+                qubit: 2, relative_start: 0, type: qf}
         1-2:
             CZ:
             - duration: 32
@@ -145,104 +83,90 @@ native_gates:
 
         4-2:
             CZ:
-            - duration: 40
-              amplitude: -0.1355 #-0.195 # -0.163
-              shape: Exponential(10, 3000, 0.05)
-              qubit: 4
-              relative_start: 0
-              type: qf
-
-
+            - {duration: 40, amplitude: -0.1355, shape: 'Exponential(10, 3000, 0.05)',
+                qubit: 4, relative_start: 0, type: qf}
 characterization:
     single_qubit:
         0:
-            readout_frequency: 7_212_301_152 #7_212_299_307
-            bare_resonator_frequency: 7_200_000_000
-            drive_frequency: 5_050_351_004
-            anharmonicity: 291_463_266
-            Ec: 270_000_000
-            Ej: 11_400_000_000
-            g: 107_000_000
-            T1: 5_857
+            readout_frequency: 7212301152
+            bare_resonator_frequency: 7200000000
+            drive_frequency: 5050222356
+            anharmonicity: 291463266
+            Ec: 270000000
+            Ej: 11400000000
+            g: 107000000
+            T1: 5857
             T2: 0
-            sweetspot: 0.5544
-
-            # parameters for single shot classification
-            iq_angle: 1.2988731608657835
-            threshold: 0.004916984424451532
-
+            sweetspot: 0.5944
+            iq_angle: 1.87610809139229
+            threshold: 0.00509979815633151
+            pi_pulse_amplitude: 0.5037576688262035
+            mean_gnd_states: [-0.0016882175134342939, -0.003335126586841177]
+            mean_exc_states: [-0.0026015215779867555, -0.006232978138739619]
         1:
-            readout_frequency: 7_453_011_071 #7_452_990_931
-            bare_resonator_frequency: 7_400_000_000
-            drive_frequency: 4_852_342_447
-            anharmonicity: 292_584_018
-            Ec: 270_000_000
-            Ej: 11_400_000_000
-            g: 114_000_00
-            T1: 1_253
+            readout_frequency: 7453011071
+            bare_resonator_frequency: 7400000000
+            drive_frequency: 4851448063
+            anharmonicity: 292584018
+            Ec: 270000000
+            Ej: 11400000000
+            g: 11400000
+            T1: 1253
             T2: 0
-            sweetspot: 0.2244
-
-            # parameters for single shot classification
-            iq_angle: -2.577474109682159
-            threshold: 0.0037870167926757105
+            sweetspot: 0.2844
+            iq_angle: 2.6915241733351234
+            threshold: 0.004502589232760579
+            pi_pulse_amplitude: 0.5091870515531648
+            mean_gnd_states: [-0.002494220030668187, -0.0005834222804035717]
+            mean_exc_states: [-0.0058959609760896705, -0.00222693779514737]
         2:
-            readout_frequency: 7_655_058_484 #7_655_083_068
-            bare_resonator_frequency: 7_600_000_000
-            drive_frequency: 5_796_172_783
-            anharmonicity: 276_187_576
-            Ec: 270_000_000
-            Ej: 16_000_000_000
-            g: 83_600_000
-            T1: 4_563
+            readout_frequency: 7655058484
+            bare_resonator_frequency: 7600000000
+            drive_frequency: 5796025841
+            anharmonicity: 276187576
+            Ec: 270000000
+            Ej: 16000000000
+            g: 83600000
+            T1: 4563
             T2: 0
-            sweetspot: -0.3762
-
-            # parameters for single shot classification
-            iq_angle: 1.3768540753196055
-            threshold: 0.0024951404045672225
+            sweetspot: -0.3562
+            iq_angle: 2.8523650124575743
+            threshold: 0.0028302188032929727
+            pi_pulse_amplitude: 0.4961740399301971
+            mean_gnd_states: [-0.0014952193335097431, -0.00010921406835205993]
+            mean_exc_states: [-0.0040435979524575255, -0.0008675397897668674]
         3:
-            readout_frequency: 7_803_438_073 #7_803_441_221
-            bare_resonator_frequency: 7_800_000_000
-            drive_frequency: 6_760_966_895
-            anharmonicity: 262_310_994
-            Ec: 270_000_000
-            Ej: 21_200_000_000
-            g: 54_300_000
-            T1: 4_232
+            readout_frequency: 7803438073
+            bare_resonator_frequency: 7800000000
+            drive_frequency: 6759863862
+            anharmonicity: 262310994
+            Ec: 270000000
+            Ej: 21200000000
+            g: 54300000
+            T1: 4232
             T2: 0
-            sweetspot: -0.8893
-
-            # parameters for single shot classification
-            iq_angle: 1.3701314535613647
-            threshold: 0.0041716330978349165
+            sweetspot: -0.74
+            iq_angle: 1.8964467227666972
+            threshold: 0.004028533776763
+            pi_pulse_amplitude: 0.4977305637146838
+            mean_gnd_states: [-0.0015922092755997937, -0.0019741712126146666]
+            mean_exc_states: [-0.002783012296958964, -0.005500677651576833]
         4:
-            readout_frequency: 8_058_917_834 #8_058_947_261
-            bare_resonator_frequency: 8_000_000_000
-            drive_frequency: 6_591_160_736
-            anharmonicity: 261_390_626
-            Ec: 270_000_000
-            Ej: 21_200_000_000
-            g: 62_700_000
+            readout_frequency: 8058917834
+            bare_resonator_frequency: 8000000000
+            drive_frequency: 6590262523
+            anharmonicity: 261390626
+            Ec: 270000000
+            Ej: 21200000000
+            g: 62700000
             T1: 492
             T2: 0
-            sweetspot: 0.5915
-
-            # parameters for single shot classification
-            iq_angle: -0.20160479111332388
-            threshold: 0.0023276844639373417
-        5:
-            readout_frequency: 7_118_627_658
-            bare_resonator_frequency: 7_000_000_000
-            drive_frequency: 4_700_000_000
-            anharmonicity: 300_000_000
-            Ec: 270_000_000
-            Ej: 11_400_000_000
-            g: 77_600_000
-            T1: 0
-            T2: 0
-            sweetspot: 0
-
-            # parameters for single shot classification
-            iq_angle: 0
-            threshold: 0.002
+            sweetspot: 0.649
+            iq_angle: -1.2566184159402678
+            threshold: 0.002205003071298744
+            pi_pulse_amplitude: 0.56468497579218
+            mean_gnd_states: [0.00040437681074607826, 0.000727654354441459]
+            mean_exc_states: [0.0012474922014940565, 0.0033223320967676277]
+        5: {readout_frequency: 7118627658, bare_resonator_frequency: 7000000000, drive_frequency: 4700000000,
+            anharmonicity: 300000000, Ec: 270000000, Ej: 11400000000, g: 77600000,
+            T1: 0, T2: 0, sweetspot: 0, iq_angle: 0, threshold: 0.002}

--- a/qw5q_gold.yml
+++ b/qw5q_gold.yml
@@ -110,25 +110,31 @@ native_gates:
         1-2:
             CZ:
             - duration: 32
-              amplitude: 0.175 # +0.16
-              shape: Exponential(2, 2700, 0.1)
+              amplitude: +0.1742 # +0.16
+              shape: Exponential(2, 5000, 0.1)
               qubit: 2
               relative_start: 0
               type: qf
+            - type: virtual_z
+              phase: 0.04
+              qubit: 1
+            - type: virtual_z
+              phase: 4.3
+              qubit: 2
 
         3-2:
             CZ:
             - duration: 32
-              amplitude: +0.6025 # +0.8 #
+              amplitude: +0.6038 # +0.8 #
               shape: Exponential(12, 5000, 0.1)
               qubit: 3
               relative_start: 0
               type: qf
             - type: virtual_z
-              phase: -0.175
+              phase: 0.14
               qubit: 2
             - type: virtual_z
-              phase: -0.86
+              phase: 2.48
               qubit: 3
 
         4-2:

--- a/qw5q_gold.yml
+++ b/qw5q_gold.yml
@@ -116,11 +116,17 @@ native_gates:
               relative_start: 0
               type: qf
             - type: virtual_z
-              phase: 0.04
+              phase: 0
               qubit: 1
             - type: virtual_z
-              phase: 4.3
+              phase: -2.24
               qubit: 2
+            - duration: 72
+              amplitude: -0.5544 # +0.16
+              shape: Exponential(12, 5000, 0.1)
+              qubit: 0
+              relative_start: 0
+              type: qf
 
         3-2:
             CZ:

--- a/qw5q_gold.yml
+++ b/qw5q_gold.yml
@@ -47,17 +47,17 @@ native_gates:
                 qubit: 2, relative_start: 0, type: qf}
         1-2:
             CZ:
-            - duration: 32
-              amplitude: +0.1742 # +0.16
+            - duration: 30
+              amplitude: +0.17505 # +0.16
               shape: Exponential(2, 5000, 0.1)
               qubit: 2
               relative_start: 0
               type: qf
             - type: virtual_z
-              phase: 0
+              phase: -6.1784
               qubit: 1
             - type: virtual_z
-              phase: -2.24
+              phase: -4.145
               qubit: 2
             - duration: 72
               amplitude: -0.5544 # +0.16

--- a/qw5q_gold.yml
+++ b/qw5q_gold.yml
@@ -55,10 +55,10 @@ native_gates:
                 qubit: 0, relative_start: 0, type: qf}
         3-2:
             CZ:
-            - {duration: 32, amplitude: 0.622, shape: 'Exponential(12, 5000, 0.1)',
+            - {duration: 32, amplitude: 0.6208, shape: 'Exponential(12, 5000, 0.1)',
                 qubit: 3, relative_start: 0, type: qf}
-            - {type: virtual_z, phase: -5.6326, qubit: 2}
-            - {type: virtual_z, phase: -1.6398, qubit: 3}
+            - {type: virtual_z, phase: -0.335, qubit: 2}
+            - {type: virtual_z, phase: -1.0301, qubit: 3}
         4-2:
             CZ:
             - {duration: 40, amplitude: -0.1355, shape: 'Exponential(10, 3000, 0.05)',

--- a/qw5q_gold.yml
+++ b/qw5q_gold.yml
@@ -88,14 +88,13 @@ native_gates:
 characterization:
     single_qubit:
         0:
-            readout_frequency: 7212301152
-            bare_resonator_frequency: 7200000000
-            drive_frequency: 5050222356
-            anharmonicity: 291463266
-            Ec: 270000000
-            Ej: 11400000000
-            g: 107000000
-            T1: 5857
+            readout_frequency: 7_212_362_551
+            drive_frequency: 5_045_070_000
+            anharmonicity: 291_463_266
+            Ec: 270_000_000
+            Ej: 11_400_000_000
+            g: 107_000_000
+            T1: 5_857
             T2: 0
             sweetspot: 0.5944
             iq_angle: 1.87610809139229
@@ -104,14 +103,13 @@ characterization:
             mean_gnd_states: [-0.0016882175134342939, -0.003335126586841177]
             mean_exc_states: [-0.0026015215779867555, -0.006232978138739619]
         1:
-            readout_frequency: 7453011071
-            bare_resonator_frequency: 7400000000
-            drive_frequency: 4851448063
-            anharmonicity: 292584018
-            Ec: 270000000
-            Ej: 11400000000
-            g: 11400000
-            T1: 1253
+            readout_frequency: 7_453_149_599
+            drive_frequency: 4_852_280_321
+            anharmonicity: 292_584_018
+            Ec: 270_000_000
+            Ej: 11_400_000_000
+            g: 114_000_000
+            T1: 1_253
             T2: 0
             sweetspot: 0.2844
             iq_angle: 2.6915241733351234
@@ -120,14 +118,13 @@ characterization:
             mean_gnd_states: [-0.002494220030668187, -0.0005834222804035717]
             mean_exc_states: [-0.0058959609760896705, -0.00222693779514737]
         2:
-            readout_frequency: 7655058484
-            bare_resonator_frequency: 7600000000
-            drive_frequency: 5796025841
-            anharmonicity: 276187576
-            Ec: 270000000
-            Ej: 16000000000
-            g: 83600000
-            T1: 4563
+            readout_frequency: 7_655_110_446
+            drive_frequency: 5_794_176_000
+            anharmonicity: 276_187_576
+            Ec: 270_000_000
+            Ej: 16_000_000_000
+            g: 83_600_000
+            T1: 4_563
             T2: 0
             sweetspot: -0.3562
             iq_angle: 2.8523650124575743
@@ -136,14 +133,13 @@ characterization:
             mean_gnd_states: [-0.0014952193335097431, -0.00010921406835205993]
             mean_exc_states: [-0.0040435979524575255, -0.0008675397897668674]
         3:
-            readout_frequency: 7803438073
-            bare_resonator_frequency: 7800000000
-            drive_frequency: 6759863862
-            anharmonicity: 262310994
-            Ec: 270000000
-            Ej: 21200000000
-            g: 54300000
-            T1: 4232
+            readout_frequency: 7_803_377_426
+            drive_frequency: 6_760_050_000
+            anharmonicity: 262_310_994
+            Ec: 270_000_000
+            Ej: 21_200_000_000
+            g: 54_300_000
+            T1: 4_232
             T2: 0
             sweetspot: -0.74
             iq_angle: 1.8964467227666972
@@ -152,21 +148,30 @@ characterization:
             mean_gnd_states: [-0.0015922092755997937, -0.0019741712126146666]
             mean_exc_states: [-0.002783012296958964, -0.005500677651576833]
         4:
-            readout_frequency: 8058917834
-            bare_resonator_frequency: 8000000000
-            drive_frequency: 6590262523
-            anharmonicity: 261390626
-            Ec: 270000000
-            Ej: 21200000000
-            g: 62700000
+            readout_frequency: 8_058_739_833
+            drive_frequency: 6_585_145_857
+            anharmonicity: 261_390_626
+            Ec: 270_000_000
+            Ej: 21_200_000_000
+            g: 62_700_000
             T1: 492
             T2: 0
-            sweetspot: 0.649
-            iq_angle: -1.2566184159402678
-            threshold: 0.002205003071298744
-            pi_pulse_amplitude: 0.56468497579218
-            mean_gnd_states: [0.00040437681074607826, 0.000727654354441459]
-            mean_exc_states: [0.0012474922014940565, 0.0033223320967676277]
-        5: {readout_frequency: 7118627658, bare_resonator_frequency: 7000000000, drive_frequency: 4700000000,
-            anharmonicity: 300000000, Ec: 270000000, Ej: 11400000000, g: 77600000,
-            T1: 0, T2: 0, sweetspot: 0, iq_angle: 0, threshold: 0.002}
+            state0_voltage: 0.0
+            state1_voltage: 0.0
+            mean_gnd_states: (-0.0+0.0j)
+            mean_exc_states: (0.0+0.0j)
+            sweetspot: 0.4555
+        5:
+            readout_frequency: 7_118_627_416
+            drive_frequency: 4_700_000_000
+            anharmonicity: 300_000_000
+            Ec: 270_000_000
+            Ej: 11_400_000_000
+            g: 77_600_000
+            T1: 0
+            T2: 0
+            state0_voltage: 0.0
+            state1_voltage: 0.0
+            mean_gnd_states: (-0.0+0.0j)
+            mean_exc_states: (0.0+0.0j)
+            sweetspot: 0

--- a/qw5q_gold.yml
+++ b/qw5q_gold.yml
@@ -47,17 +47,17 @@ native_gates:
                 qubit: 2, relative_start: 0, type: qf}
         1-2:
             CZ:
-            - duration: 30
-              amplitude: +0.17505 # +0.16
+            - duration: 32
+              amplitude: 0.1679 # +0.16
               shape: Exponential(2, 5000, 0.1)
               qubit: 2
               relative_start: 0
               type: qf
             - type: virtual_z
-              phase: -6.1784
+              phase: -3.239
               qubit: 1
             - type: virtual_z
-              phase: -4.145
+              phase: -0.1722
               qubit: 2
             - duration: 72
               amplitude: -0.5544 # +0.16
@@ -68,17 +68,17 @@ native_gates:
 
         3-2:
             CZ:
-            - duration: 30
-              amplitude: +0.5803 # +0.8 #
+            - duration: 32
+              amplitude: 0.559186 # 563
               shape: Exponential(12, 5000, 0.1)
               qubit: 3
               relative_start: 0
               type: qf
             - type: virtual_z
-              phase: -0.1204
+              phase: -5.6326
               qubit: 2
             - type: virtual_z
-              phase: -5.57
+              phase: -1.6398
               qubit: 3
 
         4-2:

--- a/qw5q_gold_qblox.py
+++ b/qw5q_gold_qblox.py
@@ -36,11 +36,11 @@ RUNCARD = pathlib.Path(__file__).parent / "qw5q_gold.yml"
 
 instruments_settings = {
     "cluster": Cluster_Settings(reference_clock_source=ReferenceClockSource.INTERNAL),
-    "qrm_rf_a": ClusterQRM_RF_Settings( #q0,q1,q5
+    "qrm_rf_a": ClusterQRM_RF_Settings(  # q0,q1,q5
         {
             "o1": ClusterRF_OutputPort_Settings(
                 channel="L3-25_a",
-                attenuation=36, #38
+                attenuation=36,  # 38
                 lo_frequency=7_255_000_000,
                 gain=0.6,
             ),
@@ -51,7 +51,7 @@ instruments_settings = {
             ),
         }
     ),
-    "qrm_rf_b": ClusterQRM_RF_Settings( #q2,q3,q4
+    "qrm_rf_b": ClusterQRM_RF_Settings(  # q2,q3,q4
         {
             "o1": ClusterRF_OutputPort_Settings(
                 channel="L3-25_b",
@@ -111,24 +111,33 @@ instruments_settings = {
     "qcm_bb0": ClusterQCM_BB_Settings(
         {
             "o2": ClusterBB_OutputPort_Settings(
-                channel="L4-5", gain=0.5, offset=0.5944, qubit=0
+                channel="L4-5",
+                gain=0.5,
+                qubit=0,  # channel="L4-5", gain=0.5, offset=0.5544, qubit=0
             )
         }
     ),
     "qcm_bb1": ClusterQCM_BB_Settings(
         {
             "o1": ClusterBB_OutputPort_Settings(
-                channel="L4-1", gain=0.5, offset=0.2844, qubit=1
+                channel="L4-1",
+                gain=0.5,
+                qubit=1,  # channel="L4-1", gain=0.5, offset=0.2244, qubit=1
             ),
             "o2": ClusterBB_OutputPort_Settings(
-                channel="L4-2", gain=0.5, offset=-0.3562, qubit=2
+                channel="L4-2",
+                gain=0.5,
+                qubit=2,  # channel="L4-2", gain=0.5, offset=-0.3762, qubit=2
             ),
             "o3": ClusterBB_OutputPort_Settings(
-                channel="L4-3", gain=0.5, offset=-0.74, qubit=3
+                channel="L4-3",
+                gain=0.5,
+                qubit=3,  # channel="L4-3", gain=0.5, offset=-0.8893, qubit=3
             ),
             "o4": ClusterBB_OutputPort_Settings(
-                channel="L4-4", gain=0.5, offset=0.649, qubit=4
-
+                channel="L4-4",
+                gain=0.5,
+                qubit=4,  # channel="L4-4", gain=0.5, offset=0.5915, qubit=4
             ),
         }
     ),

--- a/qw5q_gold_qblox.py
+++ b/qw5q_gold_qblox.py
@@ -111,23 +111,23 @@ instruments_settings = {
     "qcm_bb0": ClusterQCM_BB_Settings(
         {
             "o2": ClusterBB_OutputPort_Settings(
-                channel="L4-5", gain=0.5, offset=0.5544, qubit=0
+                channel="L4-5", gain=0.5, offset=0.5944, qubit=0
             )
         }
     ),
     "qcm_bb1": ClusterQCM_BB_Settings(
         {
             "o1": ClusterBB_OutputPort_Settings(
-                channel="L4-1", gain=0.5, offset=0.2244, qubit=1                
+                channel="L4-1", gain=0.5, offset=0.2844, qubit=1
             ),
             "o2": ClusterBB_OutputPort_Settings(
-                channel="L4-2", gain=0.5, offset=-0.3762, qubit=2                
+                channel="L4-2", gain=0.5, offset=-0.3562, qubit=2
             ),
             "o3": ClusterBB_OutputPort_Settings(
-                channel="L4-3", gain=0.5, offset=-0.8893, qubit=3
+                channel="L4-3", gain=0.5, offset=-0.74, qubit=3
             ),
             "o4": ClusterBB_OutputPort_Settings(
-                channel="L4-4", gain=0.5, offset=0.5915, qubit=4
+                channel="L4-4", gain=0.5, offset=0.649, qubit=4
 
             ),
         }

--- a/tii1q_b1.py
+++ b/tii1q_b1.py
@@ -19,12 +19,12 @@ def create(runcard=RUNCARD):
     # Instantiate QICK instruments
     controller = RFSoC(NAME, ADDRESS, PORT)
     controller.cfg.adc_trig_offset = 200
-    controller.cfg.repetition_duration = 200
+    controller.cfg.repetition_duration = 70
     # Create channel objects
     channels = ChannelMap()
-    channels |= Channel("L3-18_ro", port=controller[0])  # readout (DAC)
-    channels |= Channel("L2-RO", port=controller[0])  # feedback (readout ADC)
-    channels |= Channel("L3-18_qd", port=controller[1])  # drive
+    channels |= Channel("L3-22_ro", port=controller[1])  # readout (DAC)
+    channels |= Channel("L1-2-RO", port=controller[0])  # feedback (readout ADC)
+    channels |= Channel("L3-22_qd", port=controller[0])  # drive
 
     local_oscillators = []
 
@@ -33,8 +33,8 @@ def create(runcard=RUNCARD):
 
     # assign channels to qubits
     qubits = platform.qubits
-    qubits[0].readout = channels["L3-18_ro"]
-    qubits[0].feedback = channels["L2-RO"]
-    qubits[0].drive = channels["L3-18_qd"]
+    qubits[0].readout = channels["L3-22_ro"]
+    qubits[0].feedback = channels["L1-2-RO"]
+    qubits[0].drive = channels["L3-22_qd"]
 
     return platform

--- a/tii1q_b1.yml
+++ b/tii1q_b1.yml
@@ -2,19 +2,29 @@ nqubits: 1
 qubits: [0]
 resonator_type: 3D
 topology: []
-settings: {nshots: 1024, relaxation_time: 100000, sampling_rate: 9830400000, adc_trig_offset: 200,
-    max_gain: 32000}
+settings: {nshots: 1024, relaxation_time: 70000, sampling_rate: 9830400000}
 native_gates:
     single_qubit:
         0:
-            RX: {duration: 40, amplitude: 0.206, frequency: 5509466992, shape: Rectangular(),
-                type: qd, start: 0, phase: 0}
-            MZ: {duration: 600, amplitude: 0.0255, frequency: 7371678989, shape: Rectangular(),
+            RX: {duration: 40, amplitude: 0.5233168083083507, frequency: 5509860131,
+                shape: Gaussian(3), type: qd, start: 0, phase: 0}
+            MZ: {duration: 1000, amplitude: 0.02, frequency: 7371805303, shape: Rectangular(),
                 type: ro, start: 0, phase: 0}
     two_qubits: {}
 characterization:
     single_qubit:
-        0: {readout_frequency: 7371678989, drive_frequency: 5509466992, pi_pulse_amplitude: 0.206,
-            T1: 11543.451107305236, T2: 4610.783737888784, threshold: -1.8996081723524363,
-            iq_angle: -1.1505466598377718, mean_gnd_states: (-0.48048985465969307-2.8138070055063613j),
-            mean_exc_states: (0.1560962663766765-1.3892691773255315j)}
+        0:
+            readout_frequency: 7369620478
+            drive_frequency: 5509860131
+            anharmonicity: 0
+            Ec: 0
+            Ej: 0
+            g: 0
+            pi_pulse_amplitude: 0.5233168083083507
+            T1: 19905.294436569755
+            T2_spin_echo: 11255.259744766483
+            T2: 4654.863660508437
+            threshold: -0.8504003476217498
+            iq_angle: 1.3807193313463897
+            mean_gnd_states: [-0.5830200868621064, 1.5302915309446254]
+            mean_exc_states: [-0.30710097719869706, 0.09619815418023887]

--- a/tii_zcu111.yml
+++ b/tii_zcu111.yml
@@ -91,6 +91,10 @@ characterization:   #TODO No characterization yet
         0:
             readout_frequency: 7_111_290_000
             drive_frequency: 5_722_860_285
+            anharmonicity: 0
+            Ec: 0
+            Ej: 0
+            g: 0
             T1: 0.0
             T2: 0.0
             sweetspot: 0.28
@@ -99,6 +103,10 @@ characterization:   #TODO No characterization yet
         1:
             readout_frequency: 7_345_317_000
             drive_frequency: 6_085_931_000
+            anharmonicity: 0
+            Ec: 0
+            Ej: 0
+            g: 0
             T1: 0.0
             T2: 0.0
             sweetspot: -0.33
@@ -107,6 +115,10 @@ characterization:   #TODO No characterization yet
         2:
             readout_frequency: 7_458_000_000
             drive_frequency: 0.0
+            anharmonicity: 0
+            Ec: 0
+            Ej: 0
+            g: 0
             T1: 0.0
             T2: 0.0
             sweetspot: -0.08


### PR DESCRIPTION
I decided to open this PR to keep everyone up to date with the development of two qubit gates for `qw5q_gold`.
This is the new runcard after the power outage.
Currently pair 32 and 12 are "calibrated" . The leakage could be reduced but at least I am able to run both chevron and tune landscape for both pairs.

Chevron 12
![image](https://github.com/qiboteam/qibolab_platforms_qrc/assets/49183315/d2c849fe-af09-46e5-bcf5-d7b16ae3681d)

Tune landscape 12
![image](https://github.com/qiboteam/qibolab_platforms_qrc/assets/49183315/f463469c-11e8-450c-8efa-8521a56fdf73)


Chevron 32
![image](https://github.com/qiboteam/qibolab_platforms_qrc/assets/49183315/8cee0240-b8ec-4252-aa99-1469153e4756)

Tune landscape 32
![image](https://github.com/qiboteam/qibolab_platforms_qrc/assets/49183315/175152fd-3980-4fd8-a23c-af17d19c3ca4)

We still need to run bell to certify how good our CZ currently is.
After that we will try to run Mermin.