### PR TITLE
Test platform creation

### DIFF
--- a/.github/workflows/rules.yml
+++ b/.github/workflows/rules.yml
@@ -17,10 +17,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install pytest
           pip install qibolab
-          export QIBOLAB_PLATFORMS=.
-      - name: Debug
-        run: |
-          ls
       - name: Test platforms
         run: |
+          export QIBOLAB_PLATFORMS=.
           pytest

--- a/.github/workflows/rules.yml
+++ b/.github/workflows/rules.yml
@@ -19,5 +19,5 @@ jobs:
           pip install qibolab
       - name: Test platforms
         run: |
-          echo "QIBOLAB_PLATFORMS=$(realpath .)" >> "$GITHUB_ENV"
+          export QIBOLAB_PLATFORMS=$(realpath .)
           pytest

--- a/.github/workflows/rules.yml
+++ b/.github/workflows/rules.yml
@@ -19,5 +19,5 @@ jobs:
           pip install qibolab
       - name: Test platforms
         run: |
-          export QIBOLAB_PLATFORMS=.
+          echo "QIBOLAB_PLATFORMS=$(realpath .)" >> "$GITHUB_ENV"
           pytest

--- a/.github/workflows/rules.yml
+++ b/.github/workflows/rules.yml
@@ -16,7 +16,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install pytest
-          pip install qibolab
+          pip install qibolab[qblox,zh,qm,rfsoc]
       - name: Test platforms
         run: |
           export QIBOLAB_PLATFORMS=$(realpath .)

--- a/.github/workflows/rules.yml
+++ b/.github/workflows/rules.yml
@@ -3,7 +3,15 @@ on: push
 jobs:
   tests:
     runs-on: ubuntu-22.04
+    defaults:
+      run:
+        shell: bash
     steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.10
       - name: Install qibolab
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/rules.yml
+++ b/.github/workflows/rules.yml
@@ -1,0 +1,13 @@
+name: Tests
+on: push
+jobs:
+  tests:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Test platforms
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest
+          pip install qibolab
+          export QIBOLAB_PLATFORMS=.
+          pytest

--- a/.github/workflows/rules.yml
+++ b/.github/workflows/rules.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Set up Python 3.10
         uses: actions/setup-python@v4
         with:
-          python-version: 3.10
+          python-version: "3.10"
       - name: Install qibolab
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/rules.yml
+++ b/.github/workflows/rules.yml
@@ -4,10 +4,15 @@ jobs:
   tests:
     runs-on: ubuntu-22.04
     steps:
-      - name: Test platforms
+      - name: Install qibolab
         run: |
           python -m pip install --upgrade pip
           pip install pytest
           pip install qibolab
           export QIBOLAB_PLATFORMS=.
+      - name: Debug
+        run: |
+          ls
+      - name: Test platforms
+        run: |
           pytest

--- a/iqm5q.py
+++ b/iqm5q.py
@@ -166,7 +166,6 @@ def create(runcard_path=RUNCARD):
     runcard = load_runcard(runcard_path)
     qubits, pairs = load_qubits(runcard)
     # assign channels to qubits and sweetspots(operating points)
-    qubits = platform.qubits
     for q in range(0, 5):
         qubits[q].feedback = channels["L3-31"]
         qubits[q].readout = channels["L2-7"]

--- a/tests/test_platforms.py
+++ b/tests/test_platforms.py
@@ -1,0 +1,25 @@
+import os
+import pathlib
+
+import pytest
+from qibolab import Platform, create_platform
+
+PATH = pathlib.Path(__file__).parent.parent
+
+
+def platform_names():
+    """Yield the names of all platforms in the repository."""
+    for filename in os.listdir(PATH):
+        split = filename.split(".")
+        if split[-1] == "py":
+            yield split[0]
+
+
+@pytest.mark.parametrize("name", platform_names())
+def test_create(name):
+    """Test that platform ``name`` can be created."""
+    platform = create_platform(name)
+    qubit = next(iter(platform.qubits))
+    rx_pulse = platform.create_RX_pulse(qubit)
+    mz_pulse = platform.create_MZ_pulse(qubit, start=rx_pulse.duration)
+    assert isinstance(platform, Platform)

--- a/tests/test_platforms.py
+++ b/tests/test_platforms.py
@@ -4,21 +4,13 @@ import pathlib
 import pytest
 from qibolab import Platform, create_platform
 
-PATH = pathlib.Path(__file__).parent.parent
+PATH = pathlib.Path(__file__).parents[1]
 
 
-def platform_names():
-    """Yield the names of all platforms in the repository."""
-    for filename in os.listdir(PATH):
-        split = filename.split(".")
-        if split[-1] == "py":
-            yield split[0]
-
-
-@pytest.mark.parametrize("name", platform_names())
-def test_create(name):
-    """Test that platform ``name`` can be created."""
-    platform = create_platform(name)
+@pytest.mark.parametrize("path", PATH.glob("*.py"))
+def test_create(path):
+    """Test that platform can be created."""
+    platform = create_platform(path.stem)
     qubit = next(iter(platform.qubits))
     rx_pulse = platform.create_RX_pulse(qubit)
     mz_pulse = platform.create_MZ_pulse(qubit, start=rx_pulse.duration)


### PR DESCRIPTION
Fixes #44 by adding a simple CI that checks creation of all platforms. The environment and Python version used is matching the `qibo` module in the cluster, to make sure that all platforms here are compatible.