### PR TITLE
Add instruments section in runcards

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,16 +17,12 @@ jobs:
         with:
           virtualenvs-create: true
           virtualenvs-in-project: true
-      - name: Disable modern installer
-        run: poetry config installer.modern-installation false
       - name: Install qibolab
         run: |
           git clone https://github.com/qiboteam/qibolab
           cd qibolab
-          poetry install --no-interaction --no-root --with tests --all-extras
-          cd ..
+          poetry install --no-interaction --with tests --all-extras
       - name: Test platforms
         run: |
-          source $VENV
-          export QIBOLAB_PLATFORMS=$(realpath .)
-          pytest tests/
+          cd qibolab
+          QIBOLAB_PLATFORMS=$(realpath ..) poetry run pytest ../tests/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,32 @@
+name: Tests using qibolab main
+on: push
+jobs:
+  tests:
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - name: Install and configure poetry
+        uses: snok/install-poetry@v1
+        with:
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+      - name: Disable modern installer
+        run: poetry config installer.modern-installation false
+      - name: Install qibolab
+        run: |
+          git clone https://github.com/qiboteam/qibolab
+          cd qibolab
+          poetry install --no-interaction --no-root --with tests --all-extras
+          cd ..
+      - name: Test platforms
+        run: |
+          source $VENV
+          export QIBOLAB_PLATFORMS=$(realpath .)
+          pytest tests/

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -1,4 +1,4 @@
-name: Tests
+name: Tests using qibolab stable
 on: push
 jobs:
   tests:

--- a/iqm5q.py
+++ b/iqm5q.py
@@ -6,7 +6,12 @@ from qibolab.channels import Channel, ChannelMap
 from qibolab.instruments.erasynth import ERA
 from qibolab.instruments.oscillator import LocalOscillator
 from qibolab.instruments.zhinst import Zurich
-from qibolab.serialize import load_qubits, load_runcard, load_settings
+from qibolab.serialize import (
+    load_instrument_settings,
+    load_qubits,
+    load_runcard,
+    load_settings,
+)
 
 RUNCARD = pathlib.Path(__file__).parent / "iqm5q.yml"
 
@@ -139,15 +144,6 @@ def create(runcard_path=RUNCARD):
     ]
 
     local_oscillators.append(ERA("twpa_fixed", TWPA_ADDRESS))
-    # TWPA Parameters
-    local_oscillators[-1].frequency = 6_690_000_000
-    local_oscillators[-1].power = -5.6
-
-    # Set Dummy LO parameters (Map only the two by two oscillators)
-    local_oscillators[0].frequency = 5_500_000_000  # For SG0 (Readout)
-    local_oscillators[1].frequency = 4_200_000_000  # For SG1 and SG2 (Drive)
-    local_oscillators[2].frequency = 4_600_000_000  # For SG3 and SG4 (Drive)
-    local_oscillators[3].frequency = 4_800_000_000  # For SG5 and SG6 (Drive)
 
     # Map LOs to channels
     ch_to_lo = {
@@ -191,4 +187,5 @@ def create(runcard_path=RUNCARD):
     instruments = {controller.name: controller}
     instruments.update({lo.name: lo for lo in local_oscillators})
     settings = load_settings(runcard)
+    instruments = load_instrument_settings(runcard, instruments)
     return Platform("IQM5q", qubits, pairs, instruments, settings, resonator_type="2D")

--- a/iqm5q.yml
+++ b/iqm5q.yml
@@ -139,7 +139,6 @@ characterization:
     single_qubit:
         0:
             readout_frequency: 5_230_200_000
-            resonator_polycoef_flux: []
             drive_frequency: 4_098_114_578 #4_098_014_578
             anharmonicity: 217_492_000
             Ec: 0
@@ -156,7 +155,6 @@ characterization:
             iq_angle:  2.602
         1:
             readout_frequency: 4.9525e+9
-            resonator_polycoef_flux: []
             drive_frequency: 4.25e+9
             anharmonicity: 0
             # Ec: 0
@@ -170,7 +168,6 @@ characterization:
             mean_exc_states: (0+0j)
         2:
             readout_frequency: 6.109e+9
-            resonator_polycoef_flux: []
             drive_frequency: 4342116873
             anharmonicity: 211_604_296
             # Ec: 0
@@ -187,7 +184,6 @@ characterization:
             iq_angle: -0.474
         3:
             readout_frequency: 5.8060e+9
-            resonator_polycoef_flux: []
             drive_frequency: 4130512577
             anharmonicity: 214_000_000
             # Ec: 0
@@ -204,7 +200,6 @@ characterization:
             iq_angle: -2.904
         4:
             readout_frequency: 5.5180e+9 #5.5240e+9
-            resonator_polycoef_flux: []
             drive_frequency: 4.24704e+9 #4.1017e+9
             anharmonicity: 0
             # Ec: 0

--- a/iqm5q.yml
+++ b/iqm5q.yml
@@ -12,6 +12,23 @@ qubits: [0, 1, 2, 3, 4, "c0", "c1", "c3", "c4"]
 
 topology: [[0, 2], [1, 2], [2, 3], [2, 4]]
 
+instruments:
+    lo_readout: # For SG0 (Readout)
+        frequency: 5_500_000_000
+        power: null
+    lo_drive_0: # For SG1 and SG2 (Drive)
+        frequency: 4_200_000_000
+        power: null
+    lo_drive_1: # For SG3 and SG4 (Drive)
+        frequency: 4_600_000_000
+        power: null
+    lo_drive_2: # For SG5 and SG6 (Drive)
+        frequency: 4_800_000_000
+        power: null
+    twpa_fixed:
+        frequency: 6_690_000_000
+        power: -5.6
+
 native_gates:
     single_qubit:
         0: # qubit number

--- a/iqm5q.yml
+++ b/iqm5q.yml
@@ -15,16 +15,12 @@ topology: [[0, 2], [1, 2], [2, 3], [2, 4]]
 instruments:
     lo_readout: # For SG0 (Readout)
         frequency: 5_500_000_000
-        power: null
     lo_drive_0: # For SG1 and SG2 (Drive)
         frequency: 4_200_000_000
-        power: null
     lo_drive_1: # For SG3 and SG4 (Drive)
         frequency: 4_600_000_000
-        power: null
     lo_drive_2: # For SG5 and SG6 (Drive)
         frequency: 4_800_000_000
-        power: null
     twpa_fixed:
         frequency: 6_690_000_000
         power: -5.6

--- a/iqm5q_q0.py
+++ b/iqm5q_q0.py
@@ -6,7 +6,12 @@ from qibolab.channels import Channel, ChannelMap
 from qibolab.instruments.erasynth import ERA
 from qibolab.instruments.oscillator import LocalOscillator
 from qibolab.instruments.zhinst import Zurich
-from qibolab.serialize import load_qubits, load_runcard, load_settings
+from qibolab.serialize import (
+    load_instrument_settings,
+    load_qubits,
+    load_runcard,
+    load_settings,
+)
 
 RUNCARD = pathlib.Path(__file__).parent / "iqm5q_q0.yml"
 
@@ -120,15 +125,7 @@ def create(runcard_path=RUNCARD):
         LocalOscillator(f"lo_{kind}", None)
         for kind in ["readout"] + [f"drive_{n}" for n in range(4)]
     ]
-
     local_oscillators.append(ERA("twpa_fixed", TWPA_ADDRESS))
-    # TWPA Parameters
-    local_oscillators[-1].frequency = 6_690_000_000
-    local_oscillators[-1].power = -5.6
-
-    # Set Dummy LO parameters (Map only the two by two oscillators)
-    local_oscillators[0].frequency = 5_500_000_000  # For SG0 (Readout)
-    local_oscillators[1].frequency = 4_200_000_000  # For SG1 and SG2 (Drive)
 
     # Map LOs to channels
     ch_to_lo = {
@@ -155,4 +152,5 @@ def create(runcard_path=RUNCARD):
     instruments = {controller.name: controller}
     instruments.update({lo.name: lo for lo in local_oscillators})
     settings = load_settings(runcard)
+    instruments = load_instrument_settings(runcard, instruments)
     return Platform("IQM5q0", qubits, pairs, instruments, settings, resonator_type="2D")

--- a/iqm5q_q0.yml
+++ b/iqm5q_q0.yml
@@ -13,10 +13,8 @@ topology: []
 instruments:
     lo_readout: # For SG0 (Readout)
         frequency: 5_500_000_000
-        power: null
     lo_drive_0: # For SG1 and SG2 (Drive)
         frequency: 4_200_000_000
-        power: null
     twpa_fixed:
         frequency: 6_690_000_000
         power: -5.6

--- a/iqm5q_q0.yml
+++ b/iqm5q_q0.yml
@@ -43,7 +43,6 @@ characterization:
     single_qubit:
         0:
             readout_frequency: 5_230_200_000
-            resonator_polycoef_flux: []
             drive_frequency: 4_098_114_578
             T1: 0.0
             T2: 0.0

--- a/iqm5q_q0.yml
+++ b/iqm5q_q0.yml
@@ -10,6 +10,17 @@ qubits: [0]
 
 topology: []
 
+instruments:
+    lo_readout: # For SG0 (Readout)
+        frequency: 5_500_000_000
+        power: null
+    lo_drive_0: # For SG1 and SG2 (Drive)
+        frequency: 4_200_000_000
+        power: null
+    twpa_fixed:
+        frequency: 6_690_000_000
+        power: -5.6
+
 native_gates:
     single_qubit:
         0: # qubit number

--- a/qw5q_gold.yml
+++ b/qw5q_gold.yml
@@ -6,6 +6,12 @@ topology:
 - [1, 2]
 - [2, 3]
 - [2, 4]
+
+instruments:
+    twpa_pump:
+        frequency: 6_535_900_000
+        power: 4
+
 native_gates:
     single_qubit:
         0:

--- a/qw5q_gold.yml
+++ b/qw5q_gold.yml
@@ -77,7 +77,6 @@ characterization:
             state1_voltage: 0
             mean_gnd_states: [-0.0007345424593255905, -0.0033851610490404607]
             mean_exc_states: [-0.00022768388266126613, -0.006746426594899088]
-            resonator_polycoef_flux: []
             threshold: 0.0047939306569503995
             iq_angle: 1.421129970769001
             mixer_drive_g: 0.0
@@ -105,7 +104,6 @@ characterization:
             state1_voltage: 0
             mean_gnd_states: [-0.0013786207510767749, 0.001756676041819825]
             mean_exc_states: [-0.004034030061438043, 0.00490006139289245]
-            resonator_polycoef_flux: []
             threshold: 0.004222680659192379
             iq_angle: -2.2722409996775217
             mixer_drive_g: 0.0
@@ -133,7 +131,6 @@ characterization:
             state1_voltage: 0
             mean_gnd_states: [-0.0015068481479900491, -6.643588015332594e-05]
             mean_exc_states: [-0.0033550746498968256, -0.0011589779098270575]
-            resonator_polycoef_flux: []
             threshold: 0.002448030667411703
             iq_angle: 2.607720782249141
             mixer_drive_g: 0.0
@@ -161,7 +158,6 @@ characterization:
             state1_voltage: 0
             mean_gnd_states: [-0.0014752192586057935, -0.001920609825870185]
             mean_exc_states: [-0.0021389499138718595, -0.005743304554281938]
-            resonator_polycoef_flux: []
             threshold: 0.0039597740132007245
             iq_angle: 1.7427114215535728
             mixer_drive_g: 0.0
@@ -189,7 +185,6 @@ characterization:
             state1_voltage: 0
             mean_gnd_states: [0.0004887100284627321, 0.0006531678162954823]
             mean_exc_states: [0.00036202629034824896, 0.0037232681337331965]
-            resonator_polycoef_flux: []
             threshold: 0.001975520367263288
             iq_angle: -1.6120366437799305
             mixer_drive_g: 0.0

--- a/qw5q_gold_qblox.py
+++ b/qw5q_gold_qblox.py
@@ -28,7 +28,12 @@ from qibolab.instruments.qblox.port import (
 )
 from qibolab.instruments.rohde_schwarz import SGS100A
 from qibolab.platform import Platform
-from qibolab.serialize import load_qubits, load_runcard, load_settings
+from qibolab.serialize import (
+    load_instrument_settings,
+    load_qubits,
+    load_runcard,
+    load_settings,
+)
 
 NAME = "qblox"
 ADDRESS = "192.168.0.20"
@@ -142,7 +147,6 @@ instruments_settings = {
             ),
         }
     ),
-    "twpa_pump": {"frequency": 6_535_900_000, "power": 4},
 }
 
 
@@ -199,12 +203,7 @@ def create(runcard_path=RUNCARD):
     #     modules[name]._debug_folder = folder
 
     controller = QbloxController("qblox_controller", cluster, modules)
-
     twpa_pump = SGS100A(name="twpa_pump", address="192.168.0.37")
-    twpa_pump.frequency = instruments_settings["twpa_pump"]["frequency"]
-    twpa_pump.power = instruments_settings["twpa_pump"]["power"]
-
-    instruments = [controller, twpa_pump]
 
     # Create channel objects
     channels = {}
@@ -263,6 +262,7 @@ def create(runcard_path=RUNCARD):
 
     instruments = {controller.name: controller, twpa_pump.name: twpa_pump}
     settings = load_settings(runcard)
+    instruments = load_instrument_settings(runcard, instruments)
     return Platform(
         "qw5q_gold_qblox", qubits, pairs, instruments, settings, resonator_type="2D"
     )

--- a/tii1q_b4_qblox.py
+++ b/tii1q_b4_qblox.py
@@ -24,7 +24,12 @@ from qibolab.instruments.qblox.port import (
 )
 from qibolab.instruments.rohde_schwarz import SGS100A
 from qibolab.platform import Platform
-from qibolab.serialize import load_qubits, load_runcard, load_settings
+from qibolab.serialize import (
+    load_instrument_settings,
+    load_qubits,
+    load_runcard,
+    load_settings,
+)
 
 NAME = "tii1qb4_qblox"
 ADDRESS = "192.168.0.20"
@@ -59,7 +64,6 @@ instruments_settings = {
             ),
         }
     ),
-    "twpa_pump": {"frequency": 6_690_000_000, "power": -5.6},
 }
 
 
@@ -99,12 +103,7 @@ def create(runcard_path=RUNCARD):
     #     modules[name]._debug_folder = folder
 
     controller = QbloxController("qblox_controller", cluster, modules)
-
     twpa_pump = ERA(name="twpa_pump", address=TWPA_ADDRESS)
-    twpa_pump.frequency = instruments_settings["twpa_pump"]["frequency"]
-    twpa_pump.power = instruments_settings["twpa_pump"]["power"]
-
-    instruments = [controller, twpa_pump]
 
     # Create channel objects
     channels = {}
@@ -137,6 +136,7 @@ def create(runcard_path=RUNCARD):
 
     instruments = {controller.name: controller, twpa_pump.name: twpa_pump}
     settings = load_settings(runcard)
+    instruments = load_instrument_settings(runcard, instruments)
     return Platform(
         "tii1qb4_qblox", qubits, pairs, instruments, settings, resonator_type="3D"
     )

--- a/tii1q_b4_qblox.yml
+++ b/tii1q_b4_qblox.yml
@@ -2,6 +2,12 @@ nqubits: 1
 qubits: [0]
 topology: []
 settings: {nshots: 1024, relaxation_time: 70000, sampling_rate: 9830400000}
+
+instruments:
+    twpa_pump:
+        frequency: 6_690_000_000
+        power: -5.6
+
 native_gates:
     single_qubit:
         0:

--- a/tii_zcu111.py
+++ b/tii_zcu111.py
@@ -4,7 +4,12 @@ from qibolab.channels import Channel, ChannelMap
 from qibolab.instruments.erasynth import ERA
 from qibolab.instruments.rfsoc import RFSoC
 from qibolab.platform import Platform
-from qibolab.serialize import load_qubits, load_runcard, load_settings
+from qibolab.serialize import (
+    load_instrument_settings,
+    load_qubits,
+    load_runcard,
+    load_settings,
+)
 
 NAME = "tii_zcu111"
 ADDRESS = "192.168.0.81"
@@ -41,11 +46,8 @@ def create(runcard_path=RUNCARD):
     channels |= Channel("L4-31_qd", port=controller[5])  # drive    dac5
     channels |= Channel("L1-24_fl", port=controller[2])  # flux     dac2
 
-    local_oscillator = ERA("ErasynthLO", LO_ADDRESS, ethernet=True)
-
     # Readout local oscillator
-    local_oscillator.frequency = 7_500_000_000
-    local_oscillator.power = 10
+    local_oscillator = ERA("ErasynthLO", LO_ADDRESS, ethernet=True)
     channels["L3-30_ro"].local_oscillator = local_oscillator
 
     # create qubit objects
@@ -72,4 +74,5 @@ def create(runcard_path=RUNCARD):
 
     instruments = {controller.name: controller, local_oscillator.name: local_oscillator}
     settings = load_settings(runcard)
+    instruments = load_instrument_settings(runcard, instruments)
     return Platform(NAME, qubits, pairs, instruments, settings, resonator_type="2D")

--- a/tii_zcu111.yml
+++ b/tii_zcu111.yml
@@ -12,6 +12,11 @@ settings:
 topology: [[2, 1]]
 
 
+instruments:
+    ErasynthLO:
+        frequency: 7_500_000_000
+        power: 10
+
 native_gates:
     single_qubit:
         0: # D1

--- a/tii_zcu216.py
+++ b/tii_zcu216.py
@@ -5,7 +5,12 @@ from qibolab.instruments.erasynth import ERA
 from qibolab.instruments.rfsoc import RFSoC
 from qibolab.instruments.rohde_schwarz import SGS100A
 from qibolab.platform import Platform
-from qibolab.serialize import load_qubits, load_runcard, load_settings
+from qibolab.serialize import (
+    load_instrument_settings,
+    load_qubits,
+    load_runcard,
+    load_settings,
+)
 
 NAME = "tii_zcu216"
 ADDRESS = "192.168.0.85"
@@ -46,16 +51,8 @@ def create(runcard_path=RUNCARD):
     channels |= Channel("L4-30", port=controller[2])  # drive
 
     twpa_lo = SGS100A("TWPA", TWPA_ADDRESS)
-    twpa_lo.frequency = 5_300_250_000
-    twpa_lo.power = -5
-
-    readout_lo = SGS100A("LO", LO_ADDRESS)
-    readout_lo.frequency = 7.6e9
-    readout_lo.power = 10
+    readout_lo = SGS100A("readout_lo", LO_ADDRESS)
     channels["L3-30"].local_oscillator = readout_lo
-
-    local_oscillators = [readout_lo, twpa_lo]
-    instruments = [controller] + local_oscillators
 
     # create qubit objects
     runcard = load_runcard(runcard_path)
@@ -83,4 +80,5 @@ def create(runcard_path=RUNCARD):
         twpa_lo.name: twpa_lo,
     }
     settings = load_settings(runcard)
+    instruments = load_instrument_settings(runcard, instruments)
     return Platform(NAME, qubits, pairs, instruments, settings, resonator_type="2D")

--- a/tii_zcu216.yml
+++ b/tii_zcu216.yml
@@ -9,6 +9,14 @@ topology:
 - [D1, D2]
 - [D1, D3]
 
+instruments:
+    readout_lo:
+        frequency: 7_600_000_000
+        power: 10
+    TWPA:
+        frequency: 5_300_250_000
+        power: -5
+
 native_gates:
     single_qubit:
         D1:


### PR DESCRIPTION
Updates runcards for the new layout implemented in qiboteam/qibolab#585. I would like to wait for qiboteam/qibolab#508 before merging this, because a few more changes may be required in the interface.

I also added a workflow that is running the platform creation test with qibolab main. We can use this to check if the runcards are compatible with main before releasing qibolab. @AleCandido can you help me on how to properly activate the poetry environment in that workflow
https://github.com/qiboteam/qibolab_platforms_qrc/blob/1d0e89d00ce159d5c9fad12bb500721113aa5047/.github/workflows/main.yml#L30
