### PR TITLE
Fixing `assignment_fidelity` typo

### DIFF
--- a/iqm5q.yml
+++ b/iqm5q.yml
@@ -179,7 +179,7 @@ characterization:
             asymmetry: 0.0
             bare_resonator_frequency_sweetspot: 0.0
             ssf_brf: 0.0
-            assigment_fidelity: 0.933
+            assignment_fidelity: 0.933
             sweetspot: 0.05
             peak_voltage: 0
             pi_pulse_amplitude: 0.634
@@ -207,7 +207,7 @@ characterization:
             asymmetry: 0.0
             bare_resonator_frequency_sweetspot: 0.0
             ssf_brf: 0.0
-            assigment_fidelity: 0.861
+            assignment_fidelity: 0.861
             sweetspot: 0.02
             peak_voltage: 0
             pi_pulse_amplitude: 0.0
@@ -235,7 +235,7 @@ characterization:
             asymmetry: 0.0
             bare_resonator_frequency_sweetspot: 0.0
             ssf_brf: 0.0
-            assigment_fidelity: 0.795
+            assignment_fidelity: 0.795
             sweetspot: 0.0 #q2 does not need flux
             T1: 0.0
             T2: 0.0
@@ -261,7 +261,7 @@ characterization:
             asymmetry: 0.0
             bare_resonator_frequency_sweetspot: 0.0
             ssf_brf: 0.0
-            assigment_fidelity: 0.0
+            assignment_fidelity: 0.0
             sweetspot: 0.0
             T1: 0.0
             T2: 0.0
@@ -287,7 +287,7 @@ characterization:
             asymmetry: 0.0
             bare_resonator_frequency_sweetspot: 0.0
             ssf_brf: 0.0
-            assigment_fidelity: 0.0
+            assignment_fidelity: 0.0
             T1: 0.0
             T2: 0.0
             sweetspot: 0

--- a/qw5q_gold.yml
+++ b/qw5q_gold.yml
@@ -70,7 +70,7 @@ characterization:
             asymmetry: 0.0
             bare_resonator_frequency_sweetspot: 0.0
             ssf_brf: 0.0
-            assigment_fidelity: 0.859
+            assignment_fidelity: 0.859
             sweetspot: 0.5427880360264379
             peak_voltage: 0
             pi_pulse_amplitude: 0.5037576688262035
@@ -101,7 +101,7 @@ characterization:
             asymmetry: 0.0
             bare_resonator_frequency_sweetspot: 0.0
             ssf_brf: 0.0
-            assigment_fidelity: 0.918
+            assignment_fidelity: 0.918
             sweetspot: 0.24054218235277314
             peak_voltage: 0
             pi_pulse_amplitude: 0.5091870515531648
@@ -132,7 +132,7 @@ characterization:
             asymmetry: 0.0
             bare_resonator_frequency_sweetspot: 0.0
             ssf_brf: 0.0
-            assigment_fidelity: 0.825
+            assignment_fidelity: 0.825
             sweetspot: -0.34751511776284993
             peak_voltage: 0
             pi_pulse_amplitude: 0.4961740399301971
@@ -163,7 +163,7 @@ characterization:
             asymmetry: 0.0
             bare_resonator_frequency_sweetspot: 0.0
             ssf_brf: 0.0
-            assigment_fidelity: 0.914
+            assignment_fidelity: 0.914
             sweetspot: -1.1064345026449074
             peak_voltage: 0
             pi_pulse_amplitude: 0.4977305637146838
@@ -194,7 +194,7 @@ characterization:
             asymmetry: 0.0
             bare_resonator_frequency_sweetspot: 0.0
             ssf_brf: 0.0
-            assigment_fidelity: 0.860
+            assignment_fidelity: 0.860
             sweetspot: 0.5950321704768161
             peak_voltage: 0
             pi_pulse_amplitude: 0.56468497579218


### PR DESCRIPTION
Same as qiboteam/qibolab#613.
Now as expected tests with the qibolab latest are passing and qibolab stable are not passing anymore.
If you want both tests to pass we could eventually remove temporarily `assignment_fidelity` from the runcard.