### PR TITLE
Updated sweetspot for qubit 0

### DIFF
--- a/iqm5q.yml
+++ b/iqm5q.yml
@@ -218,7 +218,7 @@ characterization:
             bare_resonator_frequency_sweetspot: 0.0
             ssf_brf: 0.0
             assignment_fidelity: 0.884
-            sweetspot: 0.17
+            sweetspot: -0.15
             peak_voltage: 0
             pi_pulse_amplitude: 0.924
             T1: 11961


### PR DESCRIPTION
Improves assignment fidelity from 51% to 84% (blobs are still gaussian).