### PR TITLE
New runcard for a subset of spinq10q qubits (q6 to q10)

### DIFF
--- a/queues.json
+++ b/queues.json
@@ -1,1 +1,1 @@
-{"dummy": "tii2q", "iqm5q": "iqm5q", "qw5q_gold": "qw5q_gold", "tii1q_b1": "tii1q_b1", "spinq10q": "spinq10q"}
+{"dummy": "tii2q", "iqm5q": "iqm5q", "qw5q_gold": "qw5q_gold", "tii1q_b1": "tii1q_b1", "spinq10q": "spinq10q",  "spinq10q_610_qblox": "spinq10q"}

--- a/spinq10q_610.yml
+++ b/spinq10q_610.yml
@@ -1,5 +1,5 @@
 nqubits: 5
-settings: {nshots: 1024, sampling_rate: 1000000000, relaxation_time: 50000}
+settings: {nshots: 1024, relaxation_time: 50000}
 qubits: [6, 7, 8, 9, 10]
 topology:
 - [6, 7]

--- a/spinq10q_610.yml
+++ b/spinq10q_610.yml
@@ -1,89 +1,61 @@
 nqubits: 5
-settings: {nshots: 1024, sampling_rate: 1_000_000_000, relaxation_time: 50_000}
+settings: {nshots: 1024, sampling_rate: 1000000000, relaxation_time: 50000}
 qubits: [6, 7, 8, 9, 10]
 topology:
 - [6, 7]
 - [7, 8]
 - [8, 9]
 - [9, 10]
-
 instruments:
-    twpa_pump1: {power:  2.50, frequency: 6380000000}
-
-    qrm_rf1:  # q6, q7, q8, q9, q10
-        o1:
-            attenuation: 42
-            lo_frequency: 7_640_000_000
-        i1:
-            acquisition_hold_off: 500
-            acquisition_duration: 2500
-
+    twpa_pump1: {power: 2.5, frequency: 6380000000}
+    qrm_rf1:
+        o1: {attenuation: 42, lo_frequency: 7640000000}
+        i1: {acquisition_hold_off: 500, acquisition_duration: 2500}
     qcm_rf2:
-        o1:
-            attenuation: 24
-            lo_frequency: 4_307_000_000  # q5,
-        o2:
-            attenuation: 24
-            lo_frequency: 5_057_000_000  # q6,
+        o1: {attenuation: 24, lo_frequency: 4307000000}
+        o2: {attenuation: 24, lo_frequency: 5057000000}
     qcm_rf3:
-        o1:
-            attenuation: 24
-            lo_frequency: 4_377_000_000  # q7,
-        o2:
-            attenuation: 24
-            lo_frequency: 4_990_000_000  # q8,
+        o1: {attenuation: 24, lo_frequency: 4377000000}
+        o2: {attenuation: 24, lo_frequency: 4990000000}
     qcm_rf4:
-        o1:
-            attenuation: 24
-            lo_frequency: 4_081_000_000  # q9, -300MHz
-        o2:
-            attenuation: 24
-            lo_frequency: 4_598_000_000  # q10, -300MHz
-
+        o1: {attenuation: 24, lo_frequency: 4081000000}
+        o2: {attenuation: 24, lo_frequency: 4598000000}
     qcm_bb1:
-        o1:
-            offset: 0.0
-        o2:
-            offset: 0.0
-        o3:
-            offset: 0.0
-        o4:
-            offset: 0.0
+        o1: {offset: 0.0}
+        o2: {offset: 0.0}
+        o3: {offset: 0.0}
+        o4: {offset: 0.0}
     qcm_bb2:
-        o1:
-            offset: 0.0
-        o2:
-            offset: 0.0
-
+        o1: {offset: 0.0}
+        o2: {offset: 0.0}
 native_gates:
     single_qubit:
         6:
-            RX: {duration: 40, amplitude: 0.2, shape: Gaussian(5), frequency: 4807000000,
+            RX: {duration: 40, amplitude: 0.484, shape: Gaussian(5), frequency: 4801782000,
                 relative_start: 0, phase: 0, type: qd}
             MZ: {duration: 2500, amplitude: 0.1, shape: Rectangular(), frequency: 7492871912,
                 relative_start: 0, phase: 0, type: ro}
         7:
-            RX: {duration: 40, amplitude: 0.2, shape: Gaussian(5), frequency: 4138000000,
+            RX: {duration: 40, amplitude: 0.236, shape: Gaussian(5), frequency: 4135329574,
                 relative_start: 0, phase: 0, type: qd}
             MZ: {duration: 2500, amplitude: 0.05, shape: Rectangular(), frequency: 7552523695,
                 relative_start: 0, phase: 0, type: ro}
         8:
-            RX: {duration: 40, amplitude: 0.2, shape: Gaussian(5), frequency: 4740000000,
+            RX: {duration: 40, amplitude: 0.367, shape: Gaussian(5), frequency: 4740188957,
                 relative_start: 0, phase: 0, type: qd}
             MZ: {duration: 2500, amplitude: 0.1, shape: Rectangular(), frequency: 7582597778,
                 relative_start: 0, phase: 0, type: ro}
         9:
-            RX: {duration: 40, amplitude: 0.2, shape: Gaussian(5), frequency: 3781000000,
+            RX: {duration: 40, amplitude: 0.358, shape: Gaussian(5), frequency: 3779672519,
                 relative_start: 0, phase: 0, type: qd}
             MZ: {duration: 2500, amplitude: 0.1, shape: Rectangular(), frequency: 7442112987,
                 relative_start: 0, phase: 0, type: ro}
         10:
-            RX: {duration: 40, amplitude: 0.2, shape: Gaussian(5), frequency: 4298000000,
+            RX: {duration: 40, amplitude: 0.306, shape: Gaussian(5), frequency: 4292535008,
                 relative_start: 0, phase: 0, type: qd}
             MZ: {duration: 2500, amplitude: 0.1, shape: Rectangular(), frequency: 7625805244,
                 relative_start: 0, phase: 0, type: ro}
     two_qubit:
-
         6-7:
             CZ:
             - {duration: 40, amplitude: 0.01, shape: Rectangular(), qubit: 6, relative_start: 0,
@@ -100,16 +72,14 @@ native_gates:
             CZ:
             - {duration: 40, amplitude: 0.01, shape: Rectangular(), qubit: 10, relative_start: 0,
                 type: qf}
-
 characterization:
     single_qubit:
         6:
             bare_resonator_frequency: 7492000000
             readout_frequency: 7492871912
-            drive_frequency: 4807000000
+            drive_frequency: 4801782000
             anharmonicity: 300000000
             sweetspot: -0.101
-            # sweetspot: 0.208 # parking
             flux_to_bias: 1.6665895049327701
             asymmetry: 0.5535122935186866
             bare_resonator_frequency_sweetspot: 7489207877
@@ -117,8 +87,8 @@ characterization:
             Ec: 0.001712748757440161
             Ej: 10.609527507376397
             g: 0.160394924514527
-            assignment_fidelity: 0
-            readout_fidelity: 0.0
+            assignment_fidelity: 0.7688277668631303
+            readout_fidelity: 0.5376555337262606
             effective_temperature: 0.0
             peak_voltage: 0
             pi_pulse_amplitude: 0.5
@@ -127,10 +97,11 @@ characterization:
             T2_spin_echo: 0
             state0_voltage: 0
             state1_voltage: 0
-            mean_gnd_states: [0, 0]
-            mean_exc_states: [0, 0]
-            threshold: 0.0
-            iq_angle: 0.0
+            mean_gnd_states: [-0.0005720913864001781, 0.0002912062960556374]
+            mean_exc_states: [-0.0013456910603438692, -0.0009485198682308265]
+            threshold: 0.0008544546479091952
+            iq_angle: 2.1286823412974463
+            kernel_path: null
             mixer_drive_g: 0.0
             mixer_drive_phi: 0.0
             mixer_readout_g: 0.0
@@ -138,10 +109,9 @@ characterization:
         7:
             bare_resonator_frequency: 7551000000
             readout_frequency: 7552523695
-            drive_frequency: 4138000000
+            drive_frequency: 4135329574
             anharmonicity: 300000000
             sweetspot: -0.7
-            # sweetspot: 1 # parking
             flux_to_bias: 0.3703033075501269
             asymmetry: 0.03846063238221964
             bare_resonator_frequency_sweetspot: 7551278196
@@ -149,8 +119,8 @@ characterization:
             Ec: 0.0009246451339489379
             Ej: 5.562311176695407
             g: 0.0916007392206866
-            assignment_fidelity: 0
-            readout_fidelity: 0.0
+            assignment_fidelity: 0.8670595939751147
+            readout_fidelity: 0.7341191879502292
             effective_temperature: 0.0
             peak_voltage: 0
             pi_pulse_amplitude: 0.5
@@ -159,10 +129,11 @@ characterization:
             T2_spin_echo: 0
             state0_voltage: 0
             state1_voltage: 0
-            mean_gnd_states: [0, 0]
-            mean_exc_states: [0, 0]
-            threshold: 0.0
-            iq_angle: 0.0
+            mean_gnd_states: [-0.0001160535190024712, 4.326571523881334e-05]
+            mean_exc_states: [-0.001442102215486815, 0.00040287673209376683]
+            threshold: 0.0008741510325367983
+            iq_angle: -2.876772098912023
+            kernel_path: null
             mixer_drive_g: 0.0
             mixer_drive_phi: 0.0
             mixer_readout_g: 0.0
@@ -170,10 +141,9 @@ characterization:
         8:
             bare_resonator_frequency: 7582000000
             readout_frequency: 7582597778
-            drive_frequency: 4740000000
+            drive_frequency: 4740188957
             anharmonicity: 300000000
             sweetspot: -0.632
-            # sweetspot: 1 # parking
             flux_to_bias: 0.4995172960641154
             asymmetry: 0.2075344332925857
             bare_resonator_frequency_sweetspot: 7581851516
@@ -181,8 +151,8 @@ characterization:
             Ec: 0.33019201147898763
             Ej: 11.890449189962764
             g: 0.04231188420111357
-            assignment_fidelity: 0
-            readout_fidelity: 0.0
+            assignment_fidelity: 0.9019318925998691
+            readout_fidelity: 0.8038637851997381
             effective_temperature: 0.0
             peak_voltage: 0
             pi_pulse_amplitude: 0.5
@@ -191,10 +161,11 @@ characterization:
             T2_spin_echo: 0
             state0_voltage: 0
             state1_voltage: 0
-            mean_gnd_states: [0, 0]
-            mean_exc_states: [0, 0]
-            threshold: 0.0
-            iq_angle: 0.0
+            mean_gnd_states: [-3.5463058260331783e-06, -0.00017972032637548392]
+            mean_exc_states: [0.0015066975838585646, -0.002206851433999129]
+            threshold: 0.0011775647739797875
+            iq_angle: 0.9304930032229667
+            kernel_path: null
             mixer_drive_g: 0.0
             mixer_drive_phi: 0.0
             mixer_readout_g: 0.0
@@ -202,7 +173,7 @@ characterization:
         9:
             bare_resonator_frequency: 7443000000
             readout_frequency: 7442112987
-            drive_frequency: 3781000000
+            drive_frequency: 3779672519
             anharmonicity: 300000000
             sweetspot: 0
             flux_to_bias: 10.000130322312259
@@ -212,8 +183,8 @@ characterization:
             Ec: 0.3031215235846714
             Ej: 11.98896584756633
             g: 0.10132930078089977
-            assignment_fidelity: 0
-            readout_fidelity: 0.0
+            assignment_fidelity: 0.6953176162409954
+            readout_fidelity: 0.39063523248199084
             effective_temperature: 0.0
             peak_voltage: 0
             pi_pulse_amplitude: 0.5
@@ -222,10 +193,11 @@ characterization:
             T2_spin_echo: 0
             state0_voltage: 0
             state1_voltage: 0
-            mean_gnd_states: [0, 0]
-            mean_exc_states: [0, 0]
-            threshold: 0.0
-            iq_angle: 0.0
+            mean_gnd_states: [-7.942958595972015e-05, -0.0008611394052073997]
+            mean_exc_states: [-0.0003415201187291831, -0.0013551334727550243]
+            threshold: 0.0010993385080668256
+            iq_angle: 2.0585873222674564
+            kernel_path: null
             mixer_drive_g: 0.0
             mixer_drive_phi: 0.0
             mixer_readout_g: 0.0
@@ -233,7 +205,7 @@ characterization:
         10:
             bare_resonator_frequency: 7626000000
             readout_frequency: 7625805244
-            drive_frequency: 4298000000
+            drive_frequency: 4292535008
             anharmonicity: 300000000
             sweetspot: 0.0
             flux_to_bias: 10.000712581827976
@@ -243,8 +215,8 @@ characterization:
             Ec: 0.3029667450053242
             Ej: 11.99519574096561
             g: 0.10837183302651561
-            assignment_fidelity: 0
-            readout_fidelity: 0.0
+            assignment_fidelity: 0.7806155861165684
+            readout_fidelity: 0.5612311722331369
             effective_temperature: 0.0
             peak_voltage: 0
             pi_pulse_amplitude: 0.5
@@ -253,10 +225,11 @@ characterization:
             T2_spin_echo: 0
             state0_voltage: 0
             state1_voltage: 0
-            mean_gnd_states: [0, 0]
-            mean_exc_states: [0, 0]
-            threshold: 0.0
-            iq_angle: 0.0
+            mean_gnd_states: [-0.0005120465184665227, 0.0010627308097887335]
+            mean_exc_states: [-0.0008820559676674747, 0.002018710787649377]
+            threshold: 0.0016282102685715892
+            iq_angle: -1.9400869386023907
+            kernel_path: null
             mixer_drive_g: 0.0
             mixer_drive_phi: 0.0
             mixer_readout_g: 0.0

--- a/spinq10q_610.yml
+++ b/spinq10q_610.yml
@@ -1,0 +1,263 @@
+nqubits: 5
+settings: {nshots: 1024, sampling_rate: 1_000_000_000, relaxation_time: 50_000}
+qubits: [6, 7, 8, 9, 10]
+topology:
+- [6, 7]
+- [7, 8]
+- [8, 9]
+- [9, 10]
+
+instruments:
+    twpa_pump1: {power:  2.50, frequency: 6380000000}
+
+    qrm_rf1:  # q6, q7, q8, q9, q10
+        o1:
+            attenuation: 42
+            lo_frequency: 7_640_000_000
+        i1:
+            acquisition_hold_off: 500
+            acquisition_duration: 2500
+
+    qcm_rf2:
+        o1:
+            attenuation: 24
+            lo_frequency: 4_307_000_000  # q5,
+        o2:
+            attenuation: 24
+            lo_frequency: 5_057_000_000  # q6,
+    qcm_rf3:
+        o1:
+            attenuation: 24
+            lo_frequency: 4_377_000_000  # q7,
+        o2:
+            attenuation: 24
+            lo_frequency: 4_990_000_000  # q8,
+    qcm_rf4:
+        o1:
+            attenuation: 24
+            lo_frequency: 4_081_000_000  # q9, -300MHz
+        o2:
+            attenuation: 24
+            lo_frequency: 4_598_000_000  # q10, -300MHz
+
+    qcm_bb1:
+        o1:
+            offset: 0.0
+        o2:
+            offset: 0.0
+        o3:
+            offset: 0.0
+        o4:
+            offset: 0.0
+    qcm_bb2:
+        o1:
+            offset: 0.0
+        o2:
+            offset: 0.0
+
+native_gates:
+    single_qubit:
+        6:
+            RX: {duration: 40, amplitude: 0.2, shape: Gaussian(5), frequency: 4807000000,
+                relative_start: 0, phase: 0, type: qd}
+            MZ: {duration: 2500, amplitude: 0.1, shape: Rectangular(), frequency: 7492871912,
+                relative_start: 0, phase: 0, type: ro}
+        7:
+            RX: {duration: 40, amplitude: 0.2, shape: Gaussian(5), frequency: 4138000000,
+                relative_start: 0, phase: 0, type: qd}
+            MZ: {duration: 2500, amplitude: 0.05, shape: Rectangular(), frequency: 7552523695,
+                relative_start: 0, phase: 0, type: ro}
+        8:
+            RX: {duration: 40, amplitude: 0.2, shape: Gaussian(5), frequency: 4740000000,
+                relative_start: 0, phase: 0, type: qd}
+            MZ: {duration: 2500, amplitude: 0.1, shape: Rectangular(), frequency: 7582597778,
+                relative_start: 0, phase: 0, type: ro}
+        9:
+            RX: {duration: 40, amplitude: 0.2, shape: Gaussian(5), frequency: 3781000000,
+                relative_start: 0, phase: 0, type: qd}
+            MZ: {duration: 2500, amplitude: 0.1, shape: Rectangular(), frequency: 7442112987,
+                relative_start: 0, phase: 0, type: ro}
+        10:
+            RX: {duration: 40, amplitude: 0.2, shape: Gaussian(5), frequency: 4298000000,
+                relative_start: 0, phase: 0, type: qd}
+            MZ: {duration: 2500, amplitude: 0.1, shape: Rectangular(), frequency: 7625805244,
+                relative_start: 0, phase: 0, type: ro}
+    two_qubit:
+
+        6-7:
+            CZ:
+            - {duration: 40, amplitude: 0.01, shape: Rectangular(), qubit: 6, relative_start: 0,
+                type: qf}
+        7-8:
+            CZ:
+            - {duration: 40, amplitude: 0.01, shape: Rectangular(), qubit: 8, relative_start: 0,
+                type: qf}
+        8-9:
+            CZ:
+            - {duration: 40, amplitude: 0.01, shape: Rectangular(), qubit: 8, relative_start: 0,
+                type: qf}
+        9-10:
+            CZ:
+            - {duration: 40, amplitude: 0.01, shape: Rectangular(), qubit: 10, relative_start: 0,
+                type: qf}
+
+characterization:
+    single_qubit:
+        6:
+            bare_resonator_frequency: 7492000000
+            readout_frequency: 7492871912
+            drive_frequency: 4807000000
+            anharmonicity: 300000000
+            sweetspot: -0.101
+            # sweetspot: 0.208 # parking
+            flux_to_bias: 1.6665895049327701
+            asymmetry: 0.5535122935186866
+            bare_resonator_frequency_sweetspot: 7489207877
+            ssf_brf: 0.0
+            Ec: 0.001712748757440161
+            Ej: 10.609527507376397
+            g: 0.160394924514527
+            assignment_fidelity: 0
+            readout_fidelity: 0.0
+            effective_temperature: 0.0
+            peak_voltage: 0
+            pi_pulse_amplitude: 0.5
+            T1: 0
+            T2: 0
+            T2_spin_echo: 0
+            state0_voltage: 0
+            state1_voltage: 0
+            mean_gnd_states: [0, 0]
+            mean_exc_states: [0, 0]
+            threshold: 0.0
+            iq_angle: 0.0
+            mixer_drive_g: 0.0
+            mixer_drive_phi: 0.0
+            mixer_readout_g: 0.0
+            mixer_readout_phi: 0.0
+        7:
+            bare_resonator_frequency: 7551000000
+            readout_frequency: 7552523695
+            drive_frequency: 4138000000
+            anharmonicity: 300000000
+            sweetspot: -0.7
+            # sweetspot: 1 # parking
+            flux_to_bias: 0.3703033075501269
+            asymmetry: 0.03846063238221964
+            bare_resonator_frequency_sweetspot: 7551278196
+            ssf_brf: 0.0
+            Ec: 0.0009246451339489379
+            Ej: 5.562311176695407
+            g: 0.0916007392206866
+            assignment_fidelity: 0
+            readout_fidelity: 0.0
+            effective_temperature: 0.0
+            peak_voltage: 0
+            pi_pulse_amplitude: 0.5
+            T1: 0
+            T2: 0
+            T2_spin_echo: 0
+            state0_voltage: 0
+            state1_voltage: 0
+            mean_gnd_states: [0, 0]
+            mean_exc_states: [0, 0]
+            threshold: 0.0
+            iq_angle: 0.0
+            mixer_drive_g: 0.0
+            mixer_drive_phi: 0.0
+            mixer_readout_g: 0.0
+            mixer_readout_phi: 0.0
+        8:
+            bare_resonator_frequency: 7582000000
+            readout_frequency: 7582597778
+            drive_frequency: 4740000000
+            anharmonicity: 300000000
+            sweetspot: -0.632
+            # sweetspot: 1 # parking
+            flux_to_bias: 0.4995172960641154
+            asymmetry: 0.2075344332925857
+            bare_resonator_frequency_sweetspot: 7581851516
+            ssf_brf: 0.0
+            Ec: 0.33019201147898763
+            Ej: 11.890449189962764
+            g: 0.04231188420111357
+            assignment_fidelity: 0
+            readout_fidelity: 0.0
+            effective_temperature: 0.0
+            peak_voltage: 0
+            pi_pulse_amplitude: 0.5
+            T1: 0
+            T2: 0
+            T2_spin_echo: 0
+            state0_voltage: 0
+            state1_voltage: 0
+            mean_gnd_states: [0, 0]
+            mean_exc_states: [0, 0]
+            threshold: 0.0
+            iq_angle: 0.0
+            mixer_drive_g: 0.0
+            mixer_drive_phi: 0.0
+            mixer_readout_g: 0.0
+            mixer_readout_phi: 0.0
+        9:
+            bare_resonator_frequency: 7443000000
+            readout_frequency: 7442112987
+            drive_frequency: 3781000000
+            anharmonicity: 300000000
+            sweetspot: 0
+            flux_to_bias: 10.000130322312259
+            asymmetry: 1.3920288326762917
+            bare_resonator_frequency_sweetspot: 7436783114
+            ssf_brf: 0.0
+            Ec: 0.3031215235846714
+            Ej: 11.98896584756633
+            g: 0.10132930078089977
+            assignment_fidelity: 0
+            readout_fidelity: 0.0
+            effective_temperature: 0.0
+            peak_voltage: 0
+            pi_pulse_amplitude: 0.5
+            T1: 0
+            T2: 0
+            T2_spin_echo: 0
+            state0_voltage: 0
+            state1_voltage: 0
+            mean_gnd_states: [0, 0]
+            mean_exc_states: [0, 0]
+            threshold: 0.0
+            iq_angle: 0.0
+            mixer_drive_g: 0.0
+            mixer_drive_phi: 0.0
+            mixer_readout_g: 0.0
+            mixer_readout_phi: 0.0
+        10:
+            bare_resonator_frequency: 7626000000
+            readout_frequency: 7625805244
+            drive_frequency: 4298000000
+            anharmonicity: 300000000
+            sweetspot: 0.0
+            flux_to_bias: 10.000712581827976
+            asymmetry: 0.017944091505718254
+            bare_resonator_frequency_sweetspot: 7622592997
+            ssf_brf: 0.0
+            Ec: 0.3029667450053242
+            Ej: 11.99519574096561
+            g: 0.10837183302651561
+            assignment_fidelity: 0
+            readout_fidelity: 0.0
+            effective_temperature: 0.0
+            peak_voltage: 0
+            pi_pulse_amplitude: 0.5
+            T1: 0
+            T2: 0
+            T2_spin_echo: 0
+            state0_voltage: 0
+            state1_voltage: 0
+            mean_gnd_states: [0, 0]
+            mean_exc_states: [0, 0]
+            threshold: 0.0
+            iq_angle: 0.0
+            mixer_drive_g: 0.0
+            mixer_drive_phi: 0.0
+            mixer_readout_g: 0.0
+            mixer_readout_phi: 0.0

--- a/spinq10q_610_qblox.py
+++ b/spinq10q_610_qblox.py
@@ -1,0 +1,117 @@
+import pathlib
+
+import networkx as nx
+import yaml
+from qibolab.channels import Channel, ChannelMap
+from qibolab.instruments.qblox.cluster import (
+    Cluster,
+    Cluster_Settings,
+    ReferenceClockSource,
+)
+from qibolab.instruments.qblox.cluster_qcm_bb import ClusterQCM_BB
+from qibolab.instruments.qblox.cluster_qcm_rf import ClusterQCM_RF
+from qibolab.instruments.qblox.cluster_qrm_rf import ClusterQRM_RF
+from qibolab.instruments.qblox.controller import QbloxController
+from qibolab.instruments.qblox.port import QbloxOutputPort
+from qibolab.instruments.rohde_schwarz import SGS100A
+from qibolab.platform import Platform
+from qibolab.serialize import (
+    load_instrument_settings,
+    load_qubits,
+    load_runcard,
+    load_settings,
+)
+
+NAME = "qblox"
+ADDRESS = "192.168.0.6"
+RUNCARD = pathlib.Path(__file__).parent / "spinq10q_610.yml"
+
+
+def create(runcard_path=RUNCARD):
+    """SpinQ 10q-chip controlled using qblox cluster.
+
+    Args:
+        runcard_path (str): Path to the runcard file.
+    """
+
+    runcard = load_runcard(runcard_path)
+    cluster = Cluster(
+        name="cluster",
+        address="192.168.0.6",
+        settings=Cluster_Settings(reference_clock_source=ReferenceClockSource.INTERNAL),
+    )
+    modules = {
+        "qrm_rf1": ClusterQRM_RF(
+            "qrm_rf1", f"{ADDRESS}:20", cluster
+        ),  # qubits q6, q7, q8, q9, q10
+        "qcm_rf2": ClusterQCM_RF("qcm_rf2", f"{ADDRESS}:12", cluster),  # qubits q5, q6
+        "qcm_rf3": ClusterQCM_RF("qcm_rf3", f"{ADDRESS}:14", cluster),  # qubits q7, q8
+        "qcm_rf4": ClusterQCM_RF("qcm_rf4", f"{ADDRESS}:16", cluster),  # qubits q9, q10
+        "qcm_bb1": ClusterQCM_BB(
+            "qcm_bb1", f"{ADDRESS}:4", cluster
+        ),  # qubits q5, q6, q7, q8
+        "qcm_bb2": ClusterQCM_BB("qcm_bb2", f"{ADDRESS}:6", cluster),  # qubits q9, q10
+    }
+    controller = QbloxController("qblox_controller", cluster, modules)
+    twpa_pump1 = SGS100A(name="twpa_pump1", address="192.168.0.39")
+
+    instruments = {
+        controller.name: controller,
+        twpa_pump1.name: twpa_pump1,
+    }
+    instruments.update(modules)
+    instruments = load_instrument_settings(runcard, instruments)
+
+    # DEBUG: debug folder = report folder
+    import os
+    from datetime import datetime
+
+    # Create channel objects
+    channels = {}
+    # readout
+    channels["L3-21"] = Channel(name="L3-21", port=modules["qrm_rf1"].ports["o1"])
+
+    # feedback
+    channels["L2-17"] = Channel(name="L2-17", port=modules["qrm_rf1"].ports["i1"])
+
+    # drive
+
+    channels["L6-6"] = Channel(name="L6-6", port=modules["qcm_rf2"].ports["o2"])
+    channels["L6-7"] = Channel(name="L6-7", port=modules["qcm_rf3"].ports["o1"])
+    channels["L6-8"] = Channel(name="L6-8", port=modules["qcm_rf3"].ports["o2"])
+    channels["L6-9"] = Channel(name="L6-9", port=modules["qcm_rf4"].ports["o1"])
+    channels["L6-10"] = Channel(name="L6-10", port=modules["qcm_rf4"].ports["o2"])
+
+    # flux
+    channels["L6-44"] = Channel(name="L6-44", port=modules["qcm_bb1"].ports["o2"])
+    channels["L6-45"] = Channel(name="L6-45", port=modules["qcm_bb1"].ports["o3"])
+    channels["L6-46"] = Channel(name="L6-46", port=modules["qcm_bb1"].ports["o4"])
+    # channels["L6-47"] = Channel(name="L6-47", port=modules["qcm_bb2"].ports["o3"])
+    # channels["L6-48"] = Channel(name="L6-48", port=modules["qcm_bb2"].ports["o4"])
+    channels["L6-47"] = Channel(name="L6-47", port=None)
+    channels["L6-48"] = Channel(name="L6-48", port=None)
+
+    # TWPA
+    channels["L3-23"] = Channel(name="L3-23", port=None)
+    channels["L3-23"].local_oscillator = twpa_pump1
+
+    # create qubit objects
+    qubits, couplers, pairs = load_qubits(runcard)
+    # assign channels to qubits
+    for q in [6, 7, 8, 9, 10]:
+        qubits[q].readout = channels["L3-21"]
+        qubits[q].feedback = channels["L2-17"]
+        qubits[q].twpa = channels["L3-23"]
+
+    for q in range(6, 11):
+        qubits[q].drive = channels[f"L6-{q}"]
+        qubits[q].flux = channels[f"L6-{38+q}"]
+        channels[f"L6-{38+q}"].qubit = qubits[q]
+        # set maximum allowed bias
+        qubits[q].flux.max_bias = 2.5
+
+    settings = load_settings(runcard)
+
+    return Platform(
+        "spinq10q_610_qblox", qubits, pairs, instruments, settings, resonator_type="2D"
+    )

--- a/spinq10q_610_qblox.py
+++ b/spinq10q_610_qblox.py
@@ -3,11 +3,6 @@ import pathlib
 import networkx as nx
 import yaml
 from qibolab.channels import Channel, ChannelMap
-from qibolab.instruments.qblox.cluster import (
-    Cluster,
-    Cluster_Settings,
-    ReferenceClockSource,
-)
 from qibolab.instruments.qblox.cluster_qcm_bb import ClusterQCM_BB
 from qibolab.instruments.qblox.cluster_qcm_rf import ClusterQCM_RF
 from qibolab.instruments.qblox.cluster_qrm_rf import ClusterQRM_RF
@@ -35,24 +30,18 @@ def create(runcard_path=RUNCARD):
     """
 
     runcard = load_runcard(runcard_path)
-    cluster = Cluster(
-        name="cluster",
-        address="192.168.0.6",
-        settings=Cluster_Settings(reference_clock_source=ReferenceClockSource.INTERNAL),
-    )
+
     modules = {
         "qrm_rf1": ClusterQRM_RF(
-            "qrm_rf1", f"{ADDRESS}:20", cluster
+            "qrm_rf1", f"{ADDRESS}:20"
         ),  # qubits q6, q7, q8, q9, q10
-        "qcm_rf2": ClusterQCM_RF("qcm_rf2", f"{ADDRESS}:12", cluster),  # qubits q5, q6
-        "qcm_rf3": ClusterQCM_RF("qcm_rf3", f"{ADDRESS}:14", cluster),  # qubits q7, q8
-        "qcm_rf4": ClusterQCM_RF("qcm_rf4", f"{ADDRESS}:16", cluster),  # qubits q9, q10
-        "qcm_bb1": ClusterQCM_BB(
-            "qcm_bb1", f"{ADDRESS}:4", cluster
-        ),  # qubits q5, q6, q7, q8
-        "qcm_bb2": ClusterQCM_BB("qcm_bb2", f"{ADDRESS}:6", cluster),  # qubits q9, q10
+        "qcm_rf2": ClusterQCM_RF("qcm_rf2", f"{ADDRESS}:12"),  # qubits q5, q6
+        "qcm_rf3": ClusterQCM_RF("qcm_rf3", f"{ADDRESS}:14"),  # qubits q7, q8
+        "qcm_rf4": ClusterQCM_RF("qcm_rf4", f"{ADDRESS}:16"),  # qubits q9, q10
+        "qcm_bb1": ClusterQCM_BB("qcm_bb1", f"{ADDRESS}:4"),  # qubits q5, q6, q7, q8
+        "qcm_bb2": ClusterQCM_BB("qcm_bb2", f"{ADDRESS}:6"),  # qubits q9, q10
     }
-    controller = QbloxController("qblox_controller", cluster, modules)
+    controller = QbloxController("qblox_controller", ADDRESS, modules)
     twpa_pump1 = SGS100A(name="twpa_pump1", address="192.168.0.39")
 
     instruments = {


### PR DESCRIPTION
Hi All,
This PR adds a new platform to be able to use a subset of spinq10q qubits. The qubits available are qubits 6 to 10.
Please note that the fluxlines of qubits 7 & 8 are not working well and require more power to bias the qubits; and the fluxlines of qubits 9 and 10 do not work at all.
Single qubit gates are not fully calibrated. I will continue to work on them.