### PR TITLE
Use `controller.ports`

### DIFF
--- a/iqm5q.py
+++ b/iqm5q.py
@@ -98,30 +98,31 @@ def create(runcard_path=RUNCARD):
     channels = ChannelMap()
     # feedback
     channels |= Channel(
-        "L2-7", port=controller[("device_shfqc", "[QACHANNELS/0/INPUT]")]
+        "L2-7", port=controller.ports(("device_shfqc", "[QACHANNELS/0/INPUT]"))
     )
     # readout
     channels |= Channel(
-        "L3-31", port=controller[("device_shfqc", "[QACHANNELS/0/OUTPUT]")]
+        "L3-31", port=controller.ports(("device_shfqc", "[QACHANNELS/0/OUTPUT]"))
     )
     # drive
     channels |= (
         Channel(
-            f"L4-{i}", port=controller[("device_shfqc", f"SGCHANNELS/{i-5}/OUTPUT")]
+            f"L4-{i}",
+            port=controller.ports(("device_shfqc", f"SGCHANNELS/{i-5}/OUTPUT")),
         )
         for i in range(15, 20)
     )
     # flux qubits (CAREFUL WITH THIS !!!)
     channels |= (
-        Channel(f"L4-{i}", port=controller[("device_hdawg", f"SIGOUTS/{i-6}")])
+        Channel(f"L4-{i}", port=controller.ports(("device_hdawg", f"SIGOUTS/{i-6}")))
         for i in range(6, 11)
     )
     # flux couplers
     channels |= (
-        Channel(f"L4-{i}", port=controller[("device_hdawg", f"SIGOUTS/{i-11+5}")])
+        Channel(f"L4-{i}", port=controller.ports(("device_hdawg", f"SIGOUTS/{i-11+5}")))
         for i in range(11, 14)
     )
-    channels |= Channel("L4-14", port=controller[("device_hdawg2", "SIGOUTS/0")])
+    channels |= Channel("L4-14", port=controller.ports(("device_hdawg2", "SIGOUTS/0")))
     # TWPA pump(EraSynth)
     channels |= Channel("L3-32")
 

--- a/tii1q_b1.py
+++ b/tii1q_b1.py
@@ -23,9 +23,9 @@ def create(runcard_path=RUNCARD):
     controller.cfg.repetition_duration = 70
     # Create channel objects
     channels = ChannelMap()
-    channels |= Channel("L3-22_ro", port=controller[1])  # readout (DAC)
-    channels |= Channel("L1-2-RO", port=controller[0])  # feedback (readout ADC)
-    channels |= Channel("L3-22_qd", port=controller[0])  # drive
+    channels |= Channel("L3-22_ro", port=controller.ports(1))  # readout (DAC)
+    channels |= Channel("L1-2-RO", port=controller.ports(0))  # feedback (readout ADC)
+    channels |= Channel("L3-22_qd", port=controller.ports(0))  # drive
 
     # create qubit objects
     runcard = load_runcard(runcard_path)

--- a/tii_zcu111.py
+++ b/tii_zcu111.py
@@ -32,19 +32,19 @@ def create(runcard_path=RUNCARD):
 
     # Create channel objects
     channels = ChannelMap()
-    channels |= Channel("L3-30_ro", port=controller[6])  # readout  dac6
+    channels |= Channel("L3-30_ro", port=controller.ports(6))  # readout  dac6
     # QUBIT 0
-    channels |= Channel("L2-4-RO_0", port=controller[0])  # feedback adc0
-    channels |= Channel("L4-29_qd", port=controller[3])  # drive    dac3
-    channels |= Channel("L1-22_fl", port=controller[0])  # flux     dac0
+    channels |= Channel("L2-4-RO_0", port=controller.ports(0))  # feedback adc0
+    channels |= Channel("L4-29_qd", port=controller.ports(3))  # drive    dac3
+    channels |= Channel("L1-22_fl", port=controller.ports(0))  # flux     dac0
     # QUBIT 1
-    channels |= Channel("L2-4-RO_1", port=controller[1])  # feedback adc1
-    channels |= Channel("L4-30_qd", port=controller[4])  # drive    dac4
-    channels |= Channel("L1-23_fl", port=controller[1])  # flux     dac1
+    channels |= Channel("L2-4-RO_1", port=controller.ports(1))  # feedback adc1
+    channels |= Channel("L4-30_qd", port=controller.ports(4))  # drive    dac4
+    channels |= Channel("L1-23_fl", port=controller.ports(1))  # flux     dac1
     # QUBIT 2
-    channels |= Channel("L2-4-RO_2", port=controller[2])  # feedback adc2
-    channels |= Channel("L4-31_qd", port=controller[5])  # drive    dac5
-    channels |= Channel("L1-24_fl", port=controller[2])  # flux     dac2
+    channels |= Channel("L2-4-RO_2", port=controller.ports(2))  # feedback adc2
+    channels |= Channel("L4-31_qd", port=controller.ports(5))  # drive    dac5
+    channels |= Channel("L1-24_fl", port=controller.ports(2))  # flux     dac2
 
     # Readout local oscillator
     local_oscillator = ERA("ErasynthLO", LO_ADDRESS, ethernet=True)

--- a/tii_zcu216.py
+++ b/tii_zcu216.py
@@ -33,22 +33,22 @@ def create(runcard_path=RUNCARD):
     # Create channel objects
     channels = ChannelMap()
 
-    channels |= Channel("L3-30", port=controller[6])  # readout
+    channels |= Channel("L3-30", port=controller.ports(6))  # readout
 
     # qubit D1
-    channels |= Channel("L2-01-0", port=controller[0])  # feedback
-    channels |= Channel("L1-21", port=controller[1])  # flux
-    channels |= Channel("L4-28", port=controller[0])  # drive
+    channels |= Channel("L2-01-0", port=controller.ports(0))  # feedback
+    channels |= Channel("L1-21", port=controller.ports(1))  # flux
+    channels |= Channel("L4-28", port=controller.ports(0))  # drive
 
     # qubit D2
-    channels |= Channel("L2-01-1", port=controller[1])  # feedback
-    channels |= Channel("L1-22", port=controller[3])  # flux
-    channels |= Channel("L4-29", port=controller[4])  # drive
+    channels |= Channel("L2-01-1", port=controller.ports(1))  # feedback
+    channels |= Channel("L1-22", port=controller.ports(3))  # flux
+    channels |= Channel("L4-29", port=controller.ports(4))  # drive
 
     # qubit D3
-    channels |= Channel("L2-01-2", port=controller[2])  # feedback
-    channels |= Channel("L1-23", port=controller[5])  # flux
-    channels |= Channel("L4-30", port=controller[2])  # drive
+    channels |= Channel("L2-01-2", port=controller.ports(2))  # feedback
+    channels |= Channel("L1-23", port=controller.ports(5))  # flux
+    channels |= Channel("L4-30", port=controller.ports(2))  # drive
 
     twpa_lo = SGS100A("TWPA", TWPA_ADDRESS)
     readout_lo = SGS100A("readout_lo", LO_ADDRESS)


### PR DESCRIPTION
In qiboteam/qibolab#739 I removed `Controller.__getitem__` and left only `Controller.ports` to access the ports for consistency, particularly because for some instruments `.ports` has more than one arguments.