### PR TITLE
David/iqm5q CZs

### DIFF
--- a/iqm5q/parameters.json
+++ b/iqm5q/parameters.json
@@ -62,7 +62,7 @@
                     "duration": 40,
                     "amplitude": 0.343,
                     "frequency": 4103174000,
-                    "shape": "Gaussian(5)",
+                    "shape": "Drag(5, 0.000)",
                     "type": "qd",
                     "relative_start": 0,
                     "phase": 0
@@ -82,7 +82,7 @@
                     "duration": 40,
                     "amplitude": 0.6,
                     "frequency": 4252836000,
-                    "shape": "Gaussian(5)",
+                    "shape": "Drag(5, 0.04)",
                     "type": "qd",
                     "relative_start": 0,
                     "phase": 0
@@ -102,7 +102,7 @@
                     "duration": 40,
                     "amplitude": 0.23,
                     "frequency": 4538318000,
-                    "shape": "Gaussian(5)",
+                    "shape": "Drag(5, 0.000)",
                     "type": "qd",
                     "relative_start": 0,
                     "phase": 0
@@ -142,7 +142,7 @@
                     "duration": 40,
                     "amplitude": 0.55,
                     "frequency": 4358819000,
-                    "shape": "Gaussian(5)",
+                    "shape": "Drag(5, 0.000)",
                     "type": "qd",
                     "relative_start": 0,
                     "phase": 0
@@ -204,27 +204,17 @@
             "0-2": {
                 "CZ": [
                     {
-                        "duration": 100,
-                        "amplitude": -0.88,
+                        "duration": 120,
+                        "amplitude": -0.922,
                         "shape": "Rectangular()",
                         "qubit": 2,
                         "relative_start": 0,
                         "type": "qf"
                     },
                     {
-                        "type": "virtual_z",
-                        "phase": -1,
-                        "qubit": 0
-                    },
-                    {
-                        "type": "virtual_z",
-                        "phase": -3,
-                        "qubit": 2
-                    },
-                    {
                         "type": "coupler",
-                        "duration": 100,
-                        "amplitude": 0.2,
+                        "duration": 120,
+                        "amplitude": 0.3,
                         "shape": "Rectangular()",
                         "coupler": 0,
                         "relative_start": 0
@@ -234,7 +224,7 @@
             "1-2": {
                 "CZ": [
                     {
-                        "duration": 100,
+                        "duration": 120,
                         "amplitude": -0.73,
                         "shape": "Rectangular()",
                         "qubit": 2,
@@ -242,19 +232,9 @@
                         "type": "qf"
                     },
                     {
-                        "type": "virtual_z",
-                        "phase": -1,
-                        "qubit": 1
-                    },
-                    {
-                        "type": "virtual_z",
-                        "phase": -3,
-                        "qubit": 2
-                    },
-                    {
                         "type": "coupler",
-                        "duration": 100,
-                        "amplitude": 0.26,
+                        "duration": 120,
+                        "amplitude": 0.2,
                         "shape": "Rectangular()",
                         "coupler": 1,
                         "relative_start": 0
@@ -264,29 +244,19 @@
             "2-3": {
                 "CZ": [
                     {
-                        "duration": 100,
-                        "amplitude": -0.82,
+                        "duration": 120,
+                        "amplitude": -0.865,
                         "shape": "Rectangular()",
                         "qubit": 2,
                         "relative_start": 0,
                         "type": "qf"
                     },
                     {
-                        "type": "virtual_z",
-                        "phase": -1,
-                        "qubit": 1
-                    },
-                    {
-                        "type": "virtual_z",
-                        "phase": -3,
-                        "qubit": 2
-                    },
-                    {
                         "type": "coupler",
-                        "duration": 100,
-                        "amplitude": 0.4,
+                        "duration": 120,
+                        "amplitude": -0.269,
                         "shape": "Rectangular()",
-                        "coupler": 1,
+                        "coupler": 3,
                         "relative_start": 0
                     }
                 ]
@@ -294,29 +264,19 @@
             "2-4": {
                 "CZ": [
                     {
-                        "duration": 100,
-                        "amplitude": -0.586,
+                        "duration": 20,
+                        "amplitude": -0.615,
                         "shape": "Rectangular()",
                         "qubit": 2,
                         "relative_start": 0,
                         "type": "qf"
                     },
                     {
-                        "type": "virtual_z",
-                        "phase": -1,
-                        "qubit": 1
-                    },
-                    {
-                        "type": "virtual_z",
-                        "phase": -3,
-                        "qubit": 2
-                    },
-                    {
                         "type": "coupler",
-                        "duration": 100,
-                        "amplitude": 0.2,
+                        "duration": 20,
+                        "amplitude": -0.515,
                         "shape": "Rectangular()",
-                        "coupler": 1,
+                        "coupler": 4,
                         "relative_start": 0
                     }
                 ]
@@ -334,8 +294,8 @@
                 "Ec": 0,
                 "g": 0,
                 "asymmetry": 0.0,
-                "assignment_fidelity": 0.8235254781329411,
-                "readout_fidelity": 0.647050956265882,
+                "assignment_fidelity": 0.8053363648522135,
+                "readout_fidelity": 0.610672729704427,
                 "sweetspot": -0.072,
                 "peak_voltage": 0,
                 "pi_pulse_amplitude": 0.343,
@@ -345,15 +305,15 @@
                 "state0_voltage": 0,
                 "state1_voltage": 0,
                 "mean_gnd_states": [
-                    0.008990299081327669,
-                    -0.13795440297100842
+                    0.0028820295664896954,
+                    -0.15826360127865877
                 ],
                 "mean_exc_states": [
-                    -0.013563900756884918,
-                    -0.6799738475896464
+                    -0.003999636446637287,
+                    -0.6543708853744394
                 ],
-                "threshold": 0.4291967610471135,
-                "iq_angle": 1.6123837568374026,
+                "threshold": 0.3967265634871901,
+                "iq_angle": 1.5846667635110743,
                 "mixer_drive_g": 0.0,
                 "mixer_drive_phi": 0.0,
                 "mixer_readout_g": 0.0,
@@ -378,15 +338,15 @@
                 "state0_voltage": 0,
                 "state1_voltage": 0,
                 "mean_gnd_states": [
-                    0.3086286922524001,
-                    0.3501121786999083
+                    0.32313734603052874,
+                    0.30733672011320606
                 ],
                 "mean_exc_states": [
-                    1.2805441216673568,
-                    0.609922008846668
+                    1.2272199811641848,
+                    0.5413836595123299
                 ],
-                "threshold": 0.8551625645029178,
-                "iq_angle": -0.26120975191722795,
+                "threshold": 0.833197237706214,
+                "iq_angle": -0.25331664521386227,
                 "mixer_drive_g": 0.0,
                 "mixer_drive_phi": 0.0,
                 "mixer_readout_g": 0.0,

--- a/iqm5q/parameters.json
+++ b/iqm5q/parameters.json
@@ -60,9 +60,9 @@
             "0": {
                 "RX": {
                     "duration": 40,
-                    "amplitude": 0.343,
-                    "frequency": 4103174000,
-                    "shape": "Drag(5, 0.000)",
+                    "amplitude": 0.720,
+                    "frequency": 3992200247,
+                    "shape": "Gaussian(5)",
                     "type": "qd",
                     "relative_start": 0,
                     "phase": 0
@@ -70,7 +70,7 @@
                 "MZ": {
                     "duration": 2000,
                     "amplitude": 0.05,
-                    "frequency": 5228650000,
+                    "frequency": 5228950000,
                     "shape": "Rectangular()",
                     "type": "ro",
                     "relative_start": 0,
@@ -288,32 +288,32 @@
         "single_qubit": {
             "0": {
                 "bare_resonator_frequency": 5221992000,
-                "readout_frequency": 5228650000,
-                "drive_frequency": 4103174000,
+                "readout_frequency": 5228950000,
+                "drive_frequency": 3992200247,
                 "anharmonicity": 217492000,
                 "Ec": 0,
                 "g": 0,
                 "asymmetry": 0.0,
-                "assignment_fidelity": 0.8053363648522135,
-                "readout_fidelity": 0.610672729704427,
-                "sweetspot": -0.072,
+                "assignment_fidelity": 0.9249030359769961,
+                "readout_fidelity": 0.8498060719539923,
+                "sweetspot": 0,
                 "peak_voltage": 0,
-                "pi_pulse_amplitude": 0.343,
+                "pi_pulse_amplitude": 0.720,
                 "T1": 19000,
                 "T2": 10000,
                 "T2_spin_echo": 0,
                 "state0_voltage": 0,
                 "state1_voltage": 0,
                 "mean_gnd_states": [
-                    0.0028820295664896954,
-                    -0.15826360127865877
+                    0.06484172199851693,
+                    -0.16180694255643766
                 ],
                 "mean_exc_states": [
-                    -0.003999636446637287,
-                    -0.6543708853744394
+                    -0.154094686088713,
+                    -1.251290029486678
                 ],
-                "threshold": 0.3967265634871901,
-                "iq_angle": 1.5846667635110743,
+                "threshold": 0.6731864066267139,
+                "iq_angle": 1.7691093997451495,
                 "mixer_drive_g": 0.0,
                 "mixer_drive_phi": 0.0,
                 "mixer_readout_g": 0.0,

--- a/iqm5q/parameters.json
+++ b/iqm5q/parameters.json
@@ -142,7 +142,7 @@
                     "duration": 40,
                     "amplitude": 0.55,
                     "frequency": 4358819000,
-                    "shape": "Drag(5, 0.000)",
+                    "shape": "Gaussian(5)",
                     "type": "qd",
                     "relative_start": 0,
                     "phase": 0
@@ -150,7 +150,7 @@
                 "MZ": {
                     "duration": 2000,
                     "amplitude": 0.04,
-                    "frequency": 5521000000,
+                    "frequency": 5526000000,
                     "shape": "Rectangular()",
                     "type": "ro",
                     "relative_start": 0,
@@ -422,8 +422,8 @@
                 "Ec": 0,
                 "g": 0,
                 "asymmetry": 0.0,
-                "assignment_fidelity": 0.8692657482947707,
-                "readout_fidelity": 0.7385314965895413,
+                "assignment_fidelity": 0.8807676875752307,
+                "readout_fidelity": 0.7615353751504614,
                 "T1": 5800,
                 "T2": 366,
                 "sweetspot": 0.0,
@@ -431,15 +431,15 @@
                 "state0_voltage": 0,
                 "state1_voltage": 0,
                 "mean_gnd_states": [
-                    0.3195583600644675,
-                    0.13156357302438035
+                    0.2114832605222194,
+                    0.37574095922380507
                 ],
                 "mean_exc_states": [
-                    1.1885306750008457,
-                    -0.081465797952825
+                    1.1462852737115254,
+                    0.7113144908155714
                 ],
-                "threshold": 0.7694321123882739,
-                "iq_angle": 0.24040965105904746,
+                "threshold": 0.8632619334641307,
+                "iq_angle": -0.3446507063696821,
                 "mixer_drive_g": 0.0,
                 "mixer_drive_phi": 0.0,
                 "mixer_readout_g": 0.0,

--- a/iqm5q/parameters.json
+++ b/iqm5q/parameters.json
@@ -205,7 +205,7 @@
                 "CZ": [
                     {
                         "duration": 120,
-                        "amplitude": -0.922,
+                        "amplitude": 0.91,
                         "shape": "Rectangular()",
                         "qubit": 2,
                         "relative_start": 0,
@@ -214,7 +214,7 @@
                     {
                         "type": "coupler",
                         "duration": 120,
-                        "amplitude": 0.3,
+                        "amplitude": 0.2,
                         "shape": "Rectangular()",
                         "coupler": 0,
                         "relative_start": 0
@@ -234,7 +234,7 @@
                     {
                         "type": "coupler",
                         "duration": 120,
-                        "amplitude": 0.2,
+                        "amplitude": 0.224,
                         "shape": "Rectangular()",
                         "coupler": 1,
                         "relative_start": 0

--- a/iqm5q/parameters.json
+++ b/iqm5q/parameters.json
@@ -82,7 +82,7 @@
                     "duration": 40,
                     "amplitude": 0.6,
                     "frequency": 4252836000,
-                    "shape": "Drag(5, 0.04)",
+                    "shape": "Gaussian(5)",
                     "type": "qd",
                     "relative_start": 0,
                     "phase": 0
@@ -101,8 +101,8 @@
                 "RX": {
                     "duration": 40,
                     "amplitude": 0.23,
-                    "frequency": 4538318000,
-                    "shape": "Drag(5, 0.000)",
+                    "frequency": 4534318000,
+                    "shape": "Gaussian(5)",
                     "type": "qd",
                     "relative_start": 0,
                     "phase": 0
@@ -110,7 +110,7 @@
                 "MZ": {
                     "duration": 2000,
                     "amplitude": 0.055,
-                    "frequency": 6106000000,
+                    "frequency": 6108000000,
                     "shape": "Rectangular()",
                     "type": "ro",
                     "relative_start": 0,
@@ -294,8 +294,8 @@
                 "Ec": 0,
                 "g": 0,
                 "asymmetry": 0.0,
-                "assignment_fidelity": 0.9249030359769961,
-                "readout_fidelity": 0.8498060719539923,
+                "assignment_fidelity": 0.9150728901966029,
+                "readout_fidelity": 0.8301457803932057,
                 "sweetspot": 0,
                 "peak_voltage": 0,
                 "pi_pulse_amplitude": 0.720,
@@ -305,15 +305,15 @@
                 "state0_voltage": 0,
                 "state1_voltage": 0,
                 "mean_gnd_states": [
-                    0.06484172199851693,
-                    -0.16180694255643766
+                    0.08916209133165708,
+                    -0.24024004094966067
                 ],
                 "mean_exc_states": [
-                    -0.154094686088713,
-                    -1.251290029486678
+                    -0.1306425130960643,
+                    -1.2847248508252866
                 ],
-                "threshold": 0.6731864066267139,
-                "iq_angle": 1.7691093997451495,
+                "threshold": 0.8443307269445143,
+                "iq_angle": 1.7782128523462721,
                 "mixer_drive_g": 0.0,
                 "mixer_drive_phi": 0.0,
                 "mixer_readout_g": 0.0,
@@ -327,8 +327,8 @@
                 "Ec": 0,
                 "g": 0,
                 "asymmetry": 0.0,
-                "assignment_fidelity": 0.9436939949177479,
-                "readout_fidelity": 0.8873879898354956,
+                "assignment_fidelity": 0.9301859034372074,
+                "readout_fidelity": 0.8603718068744148,
                 "sweetspot": 0.0,
                 "peak_voltage": 0,
                 "pi_pulse_amplitude": 0.31,
@@ -338,15 +338,15 @@
                 "state0_voltage": 0,
                 "state1_voltage": 0,
                 "mean_gnd_states": [
-                    0.32313734603052874,
-                    0.30733672011320606
+                    0.3333116325230782,
+                    0.33688213520852467
                 ],
                 "mean_exc_states": [
-                    1.2272199811641848,
-                    0.5413836595123299
+                    1.2534506847915403,
+                    0.5817615415393582
                 ],
-                "threshold": 0.833197237706214,
-                "iq_angle": -0.25331664521386227,
+                "threshold": 0.8948756333402015,
+                "iq_angle": -0.26010412959689083,
                 "mixer_drive_g": 0.0,
                 "mixer_drive_phi": 0.0,
                 "mixer_readout_g": 0.0,
@@ -360,8 +360,8 @@
                 "Ec": 0,
                 "g": 0,
                 "asymmetry": 0.0,
-                "assignment_fidelity": 0.8756185635950248,
-                "readout_fidelity": 0.7512371271900495,
+                "assignment_fidelity": 0.8540189915741607,
+                "readout_fidelity": 0.7080379831483216,
                 "sweetspot": 0.0,
                 "T1": 10089,
                 "T2": 972,
@@ -369,15 +369,15 @@
                 "state0_voltage": 0,
                 "state1_voltage": 0,
                 "mean_gnd_states": [
-                    -0.7586969973442823,
-                    0.5051551402524129
+                    -0.6944489381824067,
+                    -0.7166103384451822
                 ],
                 "mean_exc_states": [
-                    -0.31880069533071576,
-                    1.1772893361182941
+                    -1.148522090349782,
+                    -0.14428242369294889
                 ],
-                "threshold": 0.4235257714240157,
-                "iq_angle": -0.9912803389513075,
+                "threshold": 0.2224217739100778,
+                "iq_angle": -2.241487232839098,
                 "mixer_drive_g": 0.0,
                 "mixer_drive_phi": 0.0,
                 "mixer_readout_g": 0.0,
@@ -391,8 +391,8 @@
                 "Ec": 0,
                 "g": 0,
                 "asymmetry": 0.0,
-                "assignment_fidelity": 0.883977531095359,
-                "readout_fidelity": 0.7679550621907183,
+                "assignment_fidelity": 0.8994249030359769,
+                "readout_fidelity": 0.798849806071954,
                 "sweetspot": 0.0,
                 "T1": 29900,
                 "T2": 160,
@@ -400,15 +400,15 @@
                 "state0_voltage": 0,
                 "state1_voltage": 0,
                 "mean_gnd_states": [
-                    1.4002000069575335,
-                    -0.39723082005461263
+                    1.3376864208357497,
+                    -0.38945812469104474
                 ],
                 "mean_exc_states": [
-                    1.349140858399147,
-                    -1.4593310552154481
+                    1.1737150944298644,
+                    -1.4478669200875867
                 ],
-                "threshold": 0.856009455710305,
-                "iq_angle": 1.618833100813461,
+                "threshold": 0.7513931536056916,
+                "iq_angle": 1.7244969348704429,
                 "mixer_drive_g": 0.0,
                 "mixer_drive_phi": 0.0,
                 "mixer_readout_g": 0.0,
@@ -422,8 +422,8 @@
                 "Ec": 0,
                 "g": 0,
                 "asymmetry": 0.0,
-                "assignment_fidelity": 0.8807676875752307,
-                "readout_fidelity": 0.7615353751504614,
+                "assignment_fidelity": 0.8655878025946235,
+                "readout_fidelity": 0.731175605189247,
                 "T1": 5800,
                 "T2": 366,
                 "sweetspot": 0.0,
@@ -431,15 +431,15 @@
                 "state0_voltage": 0,
                 "state1_voltage": 0,
                 "mean_gnd_states": [
-                    0.2114832605222194,
-                    0.37574095922380507
+                    -0.4367427831939406,
+                    -0.795188209749556
                 ],
                 "mean_exc_states": [
-                    1.1462852737115254,
-                    0.7113144908155714
+                    -1.6323047920351772,
+                    -0.5533672644097225
                 ],
-                "threshold": 0.8632619334641307,
-                "iq_angle": -0.3446507063696821,
+                "threshold": 0.8162519994534018,
+                "iq_angle": -2.942019682173514,
                 "mixer_drive_g": 0.0,
                 "mixer_drive_phi": 0.0,
                 "mixer_readout_g": 0.0,

--- a/iqm5q/platform.py
+++ b/iqm5q/platform.py
@@ -139,7 +139,7 @@ def create():
 
     # drive
     # The instrument selects the closest available Range [-30. -25. -20. -15. -10.  -5.   0.   5.  10.]
-    channels["L4-15"].power_range = -5  # q0
+    channels["L4-15"].power_range = -10  # q0
     channels["L4-16"].power_range = 5  # q1
     channels["L4-17"].power_range = -5  # q2
     channels["L4-18"].power_range = 10  # q3


### PR DESCRIPTION
First CZ characterization for iqm5q chip pairs

1. CZ q1q2 raw characterized. Still could be improved and landscape not executed yet [WIP]
3. CZ q3q2 raw characterized. Still could be improved and landscape not executed yet [WIP]
4. CZ q0q2 Coupler activation point not found yet [WIP]
5. CZ q4q2. Possible HW problem. Vertical band patterns found consistently after 20ns of execution in chevron coupler routine. the bans does not allow me to find the activation point. Trying some things to see if we can find the point.

Check complete report in Notion:
https://www.notion.so/qcomp/e0c0346bf4d449c2b0c1e0785067e533?v=c5c2aa2c3fa1497faf893043b12cf3f4&p=5786fd3a50164db0a5c777c1ec3e0a9c&pm=s

