### PR TITLE
Shorter readout for qwq5 platinum

### DIFF
--- a/qw5q_platinum/parameters.json
+++ b/qw5q_platinum/parameters.json
@@ -185,8 +185,8 @@
                     "type": "qd"
                 },
                 "MZ": {
-                    "duration": 2000,
-                    "amplitude": 0.01,
+                    "duration": 1300,
+                    "amplitude": 0.016,
                     "shape": "Rectangular()",
                     "frequency": 7495403662,
                     "relative_start": 0,
@@ -392,7 +392,7 @@
                 "effective_temperature": 0.0,
                 "peak_voltage": 0,
                 "pi_pulse_amplitude": 0.448,
-                "resonator_depletion_time": 0,
+                "resonator_depletion_time": 2000,
                 "T1": 41631,
                 "T2": 29884,
                 "T2_spin_echo": 0,


### PR DESCRIPTION
Trying to reduce readout time in order to improve the now limited by coherence times QND measure.

q0: 
High resonator depletion time (4.5us) The allxy results is already decaying due to coherence times.
http://login.qrccluster.com:9000/MHuZP_4OTa-U-6JWFFCf4Q==
np.exp(-t_sequence/T1) [t_sequence = 2 readouts + depletion] gives a max fidelity of 0.818 for the T1 value around 40 us. I will suggest not to use this qubit restlessly until we can deplete the resonator faster.

q2:
Lower resonator depletion time (2us)
http://login.qrccluster.com:9000/wvOYGOkqS0-cV5JTQzxYZw==
Shorter readout (QND = 0.91)
http://login.qrccluster.com:9000/V_XRXA70R56OiCNmQK1EQg==/

q3: Uncalibrated qubit (pi-pulse not working)
