### PR TITLE
Reduce readout power of D2, D3

### DIFF
--- a/qw11q/parameters.json
+++ b/qw11q/parameters.json
@@ -643,7 +643,7 @@
                 },
                 "MZ": {
                     "duration": 2000,
-                    "amplitude": 0.002,
+                    "amplitude": 0.0012,
                     "shape": "Rectangular()",
                     "frequency": 7379568000,
                     "relative_start": 0,
@@ -672,7 +672,7 @@
                 },
                 "MZ": {
                     "duration": 2000,
-                    "amplitude": 0.0011,
+                    "amplitude": 0.0009,
                     "shape": "Rectangular()",
                     "frequency": 7490960000,
                     "relative_start": 0,


### PR DESCRIPTION
Reduced a bit the readout pulse amplitude to get better blob shapes (less tails).
* Before: http://login.qrccluster.com:9000/TKkpKJzOSJCZrC_Yvtph0A==
* After: http://login.qrccluster.com:9000/sn2_g81ETz-NGvg41bXkcA==