### PR TITLE
Remove uncalibrated thresholds from qw11q

### DIFF
--- a/qw11q/parameters.json
+++ b/qw11q/parameters.json
@@ -834,8 +834,6 @@
                     0,
                     0
                 ],
-                "threshold": null,
-                "iq_angle": 0.0,
                 "mixer_drive_g": 0.0,
                 "mixer_drive_phi": 0.0,
                 "mixer_readout_g": 0.0,
@@ -889,8 +887,6 @@
                     0,
                     0
                 ],
-                "threshold": null,
-                "iq_angle": 0.0,
                 "mixer_drive_g": 0.0,
                 "mixer_drive_phi": 0.0,
                 "mixer_readout_g": 0.0,
@@ -944,8 +940,6 @@
                     0,
                     0
                 ],
-                "threshold": null,
-                "iq_angle": 0.0,
                 "mixer_drive_g": 0.0,
                 "mixer_drive_phi": 0.0,
                 "mixer_readout_g": 0.0,
@@ -999,8 +993,6 @@
                     0,
                     0
                 ],
-                "threshold": null,
-                "iq_angle": 0.0,
                 "mixer_drive_g": 0.0,
                 "mixer_drive_phi": 0.0,
                 "mixer_readout_g": 0.0,
@@ -1054,8 +1046,6 @@
                     0,
                     0
                 ],
-                "threshold": null,
-                "iq_angle": 0.0,
                 "mixer_drive_g": 0.0,
                 "mixer_drive_phi": 0.0,
                 "mixer_readout_g": 0.0,
@@ -1109,8 +1099,6 @@
                     0,
                     0
                 ],
-                "threshold": null,
-                "iq_angle": 0.0,
                 "mixer_drive_g": 0.0,
                 "mixer_drive_phi": 0.0,
                 "mixer_readout_g": 0.0,


### PR DESCRIPTION
To test https://github.com/qiboteam/qibolab/pull/980 and to avoid errors when executing circuits.