### PR TITLE
Fine tuning D1 and D2 in `qw11q`

### DIFF
--- a/qw11q/parameters.json
+++ b/qw11q/parameters.json
@@ -152,6 +152,52 @@
                 "gain": 10
             }
         },
+        "con9": {
+            "o3": {
+                "filter": {
+                    "feedforward": [
+                        1.0684635881381783,
+                        -1.0163217174522334
+                    ],
+                    "feedback": [
+                        0.947858129314055
+                    ]
+                }
+            },
+            "o4": {
+                "filter": {
+                    "feedforward": [
+                        1.0668,
+                        -1.0162
+                    ],
+                    "feedback": [
+                        0.948
+                    ]
+                }
+            },
+            "o5": {
+                "filter": {
+                    "feedforward": [
+                        1.0684635881381783,
+                        -1.0163217174522334
+                    ],
+                    "feedback": [
+                        0.947858129314055
+                    ]
+                }
+            },
+            "o6": {
+                "filter": {
+                    "feedforward": [
+                        1.0668,
+                        -1.0162
+                    ],
+                    "feedback": [
+                        0.948
+                    ]
+                }
+            }
+        },
         "octave2": {
             "o1": {
                 "lo_frequency": 7430000000,
@@ -596,9 +642,9 @@
             "D1": {
                 "RX": {
                     "duration": 40,
-                    "amplitude": 0.041440192558470756,
+                    "amplitude": 0.04075445874194751,
                     "shape": "Gaussian(5)",
-                    "frequency": 4958316314,
+                    "frequency": 4958442235,
                     "relative_start": 0,
                     "phase": 0,
                     "type": "qd"
@@ -625,9 +671,9 @@
             "D2": {
                 "RX": {
                     "duration": 40,
-                    "amplitude": 0.05515511034194706,
+                    "amplitude": 0.05360603103743127,
                     "shape": "Gaussian(5)",
-                    "frequency": 5563928012,
+                    "frequency": 5563918822,
                     "relative_start": 0,
                     "phase": 0,
                     "type": "qd"
@@ -654,9 +700,9 @@
             "D3": {
                 "RX": {
                     "duration": 40,
-                    "amplitude": 0.07072246628636102,
+                    "amplitude": 0.06936499259707336,
                     "shape": "Gaussian(5)",
-                    "frequency": 5652406433,
+                    "frequency": 5652474645,
                     "relative_start": 0,
                     "phase": 0,
                     "type": "qd"
@@ -683,9 +729,9 @@
             "D4": {
                 "RX": {
                     "duration": 40,
-                    "amplitude": 0.08027867962133999,
+                    "amplitude": 0.07876150680762735,
                     "shape": "Drag(5, 0.4)",
-                    "frequency": 6249398266,
+                    "frequency": 6249324670,
                     "relative_start": 0,
                     "phase": 0,
                     "type": "qd"
@@ -743,22 +789,106 @@
             "D1-D2": {
                 "CZ": [
                     {
-                        "duration": 70,
-                        "amplitude": 0.2,
-                        "shape": "GaussianSquare(5, 0.9)",
+                        "duration": 48,
+                        "amplitude": 0.2075,
+                        "shape": "Rectangular()",
                         "qubit": "D2",
                         "relative_start": 0,
                         "type": "qf"
                     },
                     {
                         "type": "virtual_z",
-                        "phase": 0.16321897638979893,
+                        "phase": 0,
                         "qubit": "D1"
                     },
                     {
                         "type": "virtual_z",
-                        "phase": 2.1407579546444087,
+                        "phase": 0,
                         "qubit": "D2"
+                    }
+                ],
+                "iSWAP": [
+                    {
+                        "duration": 80,
+                        "amplitude": 0.25,
+                        "shape": "Rectangular()",
+                        "qubit": "D2",
+                        "relative_start": 0,
+                        "type": "qf"
+                    },
+                    {
+                        "type": "virtual_z",
+                        "phase": 0,
+                        "qubit": "D1"
+                    },
+                    {
+                        "type": "virtual_z",
+                        "phase": 0,
+                        "qubit": "D2"
+                    }
+                ]
+            },
+            "D1-D3": {
+                "CZ": [
+                    {
+                        "duration": 37,
+                        "amplitude": 0.2333,
+                        "shape": "Rectangular()",
+                        "qubit": "D3",
+                        "relative_start": 0,
+                        "type": "qf"
+                    },
+                    {
+                        "type": "virtual_z",
+                        "phase": 0,
+                        "qubit": "D1"
+                    },
+                    {
+                        "type": "virtual_z",
+                        "phase": 0,
+                        "qubit": "D3"
+                    }
+                ],
+                "iSWAP": [
+                    {
+                        "duration": 80,
+                        "amplitude": 0.25,
+                        "shape": "Rectangular()",
+                        "qubit": "D2",
+                        "relative_start": 0,
+                        "type": "qf"
+                    },
+                    {
+                        "type": "virtual_z",
+                        "phase": 0,
+                        "qubit": "D1"
+                    },
+                    {
+                        "type": "virtual_z",
+                        "phase": 0,
+                        "qubit": "D3"
+                    }
+                ]
+            },
+            "D2-D4": {
+                "CZ": [
+                    {
+                        "duration": 70,
+                        "amplitude": 0.22,
+                        "shape": "Rectangular()",
+                        "qubit": "D4",
+                        "relative_start": 0,
+                        "type": "qf"
+                    },
+                    {
+                        "type": "virtual_z",
+                        "phase": 0,
+                        "qubit": "D2"
+                    },
+                    {
+                        "type": "virtual_z",
+                        "phase": 0,
+                        "qubit": "D4"
                     }
                 ],
                 "iSWAP": [
@@ -834,6 +964,8 @@
                     0,
                     0
                 ],
+                "threshold": 0.0,
+                "iq_angle": 0.0,
                 "mixer_drive_g": 0.0,
                 "mixer_drive_phi": 0.0,
                 "mixer_readout_g": 0.0,
@@ -887,6 +1019,8 @@
                     0,
                     0
                 ],
+                "threshold": 0.0,
+                "iq_angle": 0.0,
                 "mixer_drive_g": 0.0,
                 "mixer_drive_phi": 0.0,
                 "mixer_readout_g": 0.0,
@@ -940,6 +1074,8 @@
                     0,
                     0
                 ],
+                "threshold": 0.0,
+                "iq_angle": 0.0,
                 "mixer_drive_g": 0.0,
                 "mixer_drive_phi": 0.0,
                 "mixer_readout_g": 0.0,
@@ -993,6 +1129,8 @@
                     0,
                     0
                 ],
+                "threshold": 0.0,
+                "iq_angle": 0.0,
                 "mixer_drive_g": 0.0,
                 "mixer_drive_phi": 0.0,
                 "mixer_readout_g": 0.0,
@@ -1046,6 +1184,8 @@
                     0,
                     0
                 ],
+                "threshold": 0.0,
+                "iq_angle": 0.0,
                 "mixer_drive_g": 0.0,
                 "mixer_drive_phi": 0.0,
                 "mixer_readout_g": 0.0,
@@ -1099,6 +1239,8 @@
                     0,
                     0
                 ],
+                "threshold": 0.0,
+                "iq_angle": 0.0,
                 "mixer_drive_g": 0.0,
                 "mixer_drive_phi": 0.0,
                 "mixer_readout_g": 0.0,
@@ -1382,9 +1524,9 @@
             "D1": {
                 "bare_resonator_frequency": 0,
                 "readout_frequency": 0,
-                "drive_frequency": 4958316314,
+                "drive_frequency": 4958442235,
                 "anharmonicity": -200000000,
-                "sweetspot": 0.31394651971665033,
+                "sweetspot": 0.318,
                 "asymmetry": 0.0,
                 "crosstalk_matrix": {
                     "A1": 0.0,
@@ -1407,8 +1549,8 @@
                 "Ec": 0.0,
                 "Ej": 0.0,
                 "g": 0.0,
-                "assignment_fidelity": 0.9625298963592879,
-                "readout_fidelity": 0.9250597927185756,
+                "assignment_fidelity": 0.9613340419877757,
+                "readout_fidelity": 0.9226680839755514,
                 "gate_fidelity": 0.0,
                 "effective_temperature": 0.0,
                 "peak_voltage": 0,
@@ -1420,15 +1562,15 @@
                 "state0_voltage": 0,
                 "state1_voltage": 0,
                 "mean_gnd_states": [
-                    0.0012463746178204406,
-                    0.00042009015998994726
+                    0.0012115522688775577,
+                    0.0005063249173571408
                 ],
                 "mean_exc_states": [
-                    0.0028337773500906795,
-                    0.0017814248831957032
+                    0.002697066928861688,
+                    0.0019343935266046045
                 ],
-                "threshold": 0.001991798128011722,
-                "iq_angle": -0.7088818070239516,
+                "threshold": 0.002189310611022657,
+                "iq_angle": -0.7656840851651331,
                 "mixer_drive_g": 0.0,
                 "mixer_drive_phi": 0.0,
                 "mixer_readout_g": 0.0,
@@ -1437,9 +1579,9 @@
             "D2": {
                 "bare_resonator_frequency": 0,
                 "readout_frequency": 0,
-                "drive_frequency": 5563928012,
+                "drive_frequency": 5563918822,
                 "anharmonicity": -200000000,
-                "sweetspot": -0.2693102674878147,
+                "sweetspot": -0.269,
                 "asymmetry": 0.0,
                 "crosstalk_matrix": {
                     "A1": 0.0,
@@ -1462,8 +1604,8 @@
                 "Ec": 0.0,
                 "Ej": 0.0,
                 "g": 0.0,
-                "assignment_fidelity": 0.9585437151209142,
-                "readout_fidelity": 0.9170874302418284,
+                "assignment_fidelity": 0.959872442200372,
+                "readout_fidelity": 0.9197448844007441,
                 "gate_fidelity": 0.0,
                 "effective_temperature": 0.0,
                 "peak_voltage": 0,
@@ -1475,15 +1617,15 @@
                 "state0_voltage": 0,
                 "state1_voltage": 0,
                 "mean_gnd_states": [
-                    0.0017283458401246411,
-                    0.0004235524719081079
+                    -0.0015866454239114262,
+                    0.0007569478016774348
                 ],
                 "mean_exc_states": [
-                    0.003341200585033296,
-                    0.0021434031999114345
+                    -0.003934135757052071,
+                    0.0005132971148826073
                 ],
-                "threshold": 0.002578995377684328,
-                "iq_angle": -0.8174919819731508,
+                "threshold": 0.0025525566133749867,
+                "iq_angle": 3.038170984923934,
                 "mixer_drive_g": 0.0,
                 "mixer_drive_phi": 0.0,
                 "mixer_readout_g": 0.0,
@@ -1492,9 +1634,9 @@
             "D3": {
                 "bare_resonator_frequency": 0,
                 "readout_frequency": 0,
-                "drive_frequency": 5652406433,
+                "drive_frequency": 5652474645,
                 "anharmonicity": -200000000,
-                "sweetspot": -0.17830274314573707,
+                "sweetspot": -0.177,
                 "asymmetry": 0.0,
                 "crosstalk_matrix": {
                     "A1": 0.0,
@@ -1517,8 +1659,8 @@
                 "Ec": 0.0,
                 "Ej": 0.0,
                 "g": 0.0,
-                "assignment_fidelity": 0.9509699707680043,
-                "readout_fidelity": 0.9019399415360085,
+                "assignment_fidelity": 0.9415360085038533,
+                "readout_fidelity": 0.8830720170077067,
                 "gate_fidelity": 0.0,
                 "effective_temperature": 0.0,
                 "peak_voltage": 0,
@@ -1530,15 +1672,15 @@
                 "state0_voltage": 0,
                 "state1_voltage": 0,
                 "mean_gnd_states": [
-                    -0.0007568075933940021,
-                    0.0008195451863762017
+                    -0.0009239978813171259,
+                    0.0005768005134812453
                 ],
                 "mean_exc_states": [
-                    -0.0030424173761960075,
-                    0.0019891447823968873
+                    -0.0033648728011628905,
+                    0.0011320199422417503
                 ],
-                "threshold": 0.002421164775577672,
-                "iq_angle": -2.6686105138809664,
+                "threshold": 0.0023215494998322806,
+                "iq_angle": -2.917930965783244,
                 "mixer_drive_g": 0.0,
                 "mixer_drive_phi": 0.0,
                 "mixer_readout_g": 0.0,
@@ -1547,9 +1689,9 @@
             "D4": {
                 "bare_resonator_frequency": 0,
                 "readout_frequency": 0,
-                "drive_frequency": 6249398266,
+                "drive_frequency": 6249324670,
                 "anharmonicity": -200000000,
-                "sweetspot": -0.4329726183619601,
+                "sweetspot": -0.433,
                 "asymmetry": 0.0,
                 "crosstalk_matrix": {
                     "A1": 0.0,
@@ -1572,8 +1714,8 @@
                 "Ec": 0.0,
                 "Ej": 0.0,
                 "g": 0.0,
-                "assignment_fidelity": 0.9613340419877756,
-                "readout_fidelity": 0.9226680839755513,
+                "assignment_fidelity": 0.9622641509433962,
+                "readout_fidelity": 0.9245283018867925,
                 "gate_fidelity": 0.0,
                 "effective_temperature": 0.0,
                 "peak_voltage": 0,
@@ -1585,15 +1727,15 @@
                 "state0_voltage": 0,
                 "state1_voltage": 0,
                 "mean_gnd_states": [
-                    0.0008629299690291497,
-                    0.0006933255115629104
+                    0.0003780047211109204,
+                    -0.0010648147378227498
                 ],
                 "mean_exc_states": [
-                    0.00041459317940554337,
-                    0.0028239388712821664
+                    0.0025465505322876556,
+                    -0.0013411586761173655
                 ],
-                "threshold": 0.0015434116678446636,
-                "iq_angle": -1.778196646998974,
+                "threshold": 0.0016417382238347856,
+                "iq_angle": 0.12674967868508633,
                 "mixer_drive_g": 0.0,
                 "mixer_drive_phi": 0.0,
                 "mixer_readout_g": 0.0,


### PR DESCRIPTION
Fine tuning qubit [D1](http://login.qrccluster.com:9000/Axlb3M4lSUuWnahWzMcQ1g==/) and [D2](http://login.qrccluster.com:9000/c4spBIw7T-6AjxSsXPYU6g==/).
I will try to upload a reasonable calibration for 2q gates as well.