### PR TITLE
Sweetspot recalibration after disconnection

### DIFF
--- a/qw11q/parameters.json
+++ b/qw11q/parameters.json
@@ -642,9 +642,9 @@
             "D1": {
                 "RX": {
                     "duration": 40,
-                    "amplitude": 0.040881590572425984,
+                    "amplitude": 0.04164625808461723,
                     "shape": "Gaussian(5)",
-                    "frequency": 4958286116,
+                    "frequency": 4958294808,
                     "relative_start": 0,
                     "phase": 0,
                     "type": "qd"
@@ -671,9 +671,9 @@
             "D2": {
                 "RX": {
                     "duration": 40,
-                    "amplitude": 0.05480563813123633,
+                    "amplitude": 0.05515418272610377,
                     "shape": "Gaussian(5)",
-                    "frequency": 5564026190,
+                    "frequency": 5564028148,
                     "relative_start": 0,
                     "phase": 0,
                     "type": "qd"
@@ -700,9 +700,9 @@
             "D3": {
                 "RX": {
                     "duration": 40,
-                    "amplitude": 0.06848719114205952,
+                    "amplitude": 0.0683291399266345,
                     "shape": "Gaussian(5)",
-                    "frequency": 5652743158,
+                    "frequency": 5652497594,
                     "relative_start": 0,
                     "phase": 0,
                     "type": "qd"
@@ -730,8 +730,8 @@
                 "RX": {
                     "duration": 40,
                     "amplitude": 0.07876150680762735,
-                    "shape": "Drag(5, 0.4)",
-                    "frequency": 6249324670,
+                    "shape": "Gaussian(5)",
+                    "frequency": 6150032162,
                     "relative_start": 0,
                     "phase": 0,
                     "type": "qd"
@@ -749,7 +749,7 @@
                     "duration": 2000,
                     "amplitude": 0.002,
                     "shape": "Rectangular()",
-                    "frequency": 7706570000,
+                    "frequency": 7704602807,
                     "relative_start": 0,
                     "phase": 0,
                     "type": "ro"
@@ -758,9 +758,9 @@
             "D5": {
                 "RX": {
                     "duration": 40,
-                    "amplitude": 0.065,
+                    "amplitude": 0.19141107032708946,
                     "shape": "Gaussian(5)",
-                    "frequency": 5526780884,
+                    "frequency": 5421335411,
                     "relative_start": 0,
                     "phase": 0,
                     "type": "qd"
@@ -1524,9 +1524,9 @@
             "D1": {
                 "bare_resonator_frequency": 0,
                 "readout_frequency": 0,
-                "drive_frequency": 4958286116,
+                "drive_frequency": 4958294808,
                 "anharmonicity": -200000000,
-                "sweetspot": 0.224,
+                "sweetspot": 0.2205,
                 "asymmetry": 0.0,
                 "crosstalk_matrix": {
                     "A1": 0.0,
@@ -1540,7 +1540,7 @@
                     "B3": 0.0,
                     "B4": 0.0,
                     "B5": 0.0,
-                    "D1": 0.7302088769870518,
+                    "D1": 0.722792218334187,
                     "D2": 0.0,
                     "D3": 0.0,
                     "D4": 0.0,
@@ -1549,8 +1549,8 @@
                 "Ec": 0.0,
                 "Ej": 0.0,
                 "g": 0.0,
-                "assignment_fidelity": 0.9668,
-                "readout_fidelity": 0.9336,
+                "assignment_fidelity": 0.9637257507307999,
+                "readout_fidelity": 0.9274515014615998,
                 "gate_fidelity": 0.0,
                 "effective_temperature": 0.0,
                 "peak_voltage": 0,
@@ -1562,15 +1562,15 @@
                 "state0_voltage": 0,
                 "state1_voltage": 0,
                 "mean_gnd_states": [
-                    0.0012362526342420295,
-                    0.00027480699044196466
+                    0.0012122945566451068,
+                    0.0004926307890977902
                 ],
                 "mean_exc_states": [
-                    0.002858743414088763,
-                    0.0013883677416426875
+                    0.0026708424909061617,
+                    0.0018984388105656408
                 ],
-                "threshold": 0.00206660062562288,
-                "iq_angle": -0.6014910275672222,
+                "threshold": 0.002100861788865835,
+                "iq_angle": -0.7669877581038627,
                 "mixer_drive_g": 0.0,
                 "mixer_drive_phi": 0.0,
                 "mixer_readout_g": 0.0,
@@ -1579,9 +1579,9 @@
             "D2": {
                 "bare_resonator_frequency": 0,
                 "readout_frequency": 0,
-                "drive_frequency": 5564026190,
-                "anharmonicity": -200000000,
-                "sweetspot": -0.395,
+                "drive_frequency": 5564028148,
+                "anharmonicity": -211000000,
+                "sweetspot": -0.421,
                 "asymmetry": 0.0,
                 "crosstalk_matrix": {
                     "A1": 0.0,
@@ -1596,16 +1596,16 @@
                     "B4": 0.0,
                     "B5": 0.0,
                     "D1": 0.0,
-                    "D2": 0.9638965985787128,
+                    "D2": 0.8709068919868691,
                     "D3": 0.0,
                     "D4": 0.0,
                     "D5": 0.0
                 },
-                "Ec": 0.0,
+                "Ec": 211000000,
                 "Ej": 0.0,
                 "g": 0.0,
-                "assignment_fidelity": 0.9632000000000001,
-                "readout_fidelity": 0.9264000000000001,
+                "assignment_fidelity": 0.9622641509433962,
+                "readout_fidelity": 0.9245283018867925,
                 "gate_fidelity": 0.0,
                 "effective_temperature": 0.0,
                 "peak_voltage": 0,
@@ -1617,15 +1617,15 @@
                 "state0_voltage": 0,
                 "state1_voltage": 0,
                 "mean_gnd_states": [
-                    -0.001469561370109089,
-                    0.0009693757401356124
+                    -0.0015725565683978875,
+                    0.0007920206960810038
                 ],
                 "mean_exc_states": [
-                    -0.003852472074553588,
-                    0.0008524025540671195
+                    -0.0038730673414736454,
+                    0.00042917761766558913
                 ],
-                "threshold": 0.002621696461984542,
-                "iq_angle": 3.092543662384623,
+                "threshold": 0.0024749776365672765,
+                "iq_angle": 2.985158502622976,
                 "mixer_drive_g": 0.0,
                 "mixer_drive_phi": 0.0,
                 "mixer_readout_g": 0.0,
@@ -1634,9 +1634,9 @@
             "D3": {
                 "bare_resonator_frequency": 0,
                 "readout_frequency": 0,
-                "drive_frequency": 5652743158,
-                "anharmonicity": -200000000,
-                "sweetspot": -0.243,
+                "drive_frequency": 5652497594,
+                "anharmonicity": -211000000,
+                "sweetspot": -0.2095,
                 "asymmetry": 0.0,
                 "crosstalk_matrix": {
                     "A1": 0.0,
@@ -1652,15 +1652,15 @@
                     "B5": 0.0,
                     "D1": 0.0,
                     "D2": 0.0,
-                    "D3": 0.8321426404187109,
+                    "D3": 0.7820116255513535,
                     "D4": 0.0,
                     "D5": 0.0
                 },
-                "Ec": 0.0,
+                "Ec": 211000000,
                 "Ej": 0.0,
                 "g": 0.0,
-                "assignment_fidelity": 0.9553,
-                "readout_fidelity": 0.9106000000000001,
+                "assignment_fidelity": 0.9476481530693596,
+                "readout_fidelity": 0.8952963061387191,
                 "gate_fidelity": 0.0,
                 "effective_temperature": 0.0,
                 "peak_voltage": 0,
@@ -1672,15 +1672,15 @@
                 "state0_voltage": 0,
                 "state1_voltage": 0,
                 "mean_gnd_states": [
-                    -0.0009229718245205025,
-                    0.0006351165846289241
+                    -0.0009620611421048146,
+                    0.00052384467651444
                 ],
                 "mean_exc_states": [
-                    -0.0033842952926441483,
-                    0.0013542098035021662
+                    -0.0034169448505460406,
+                    0.0009228957669946573
                 ],
-                "threshold": 0.0022953048928512146,
-                "iq_angle": -2.8573465860910017,
+                "threshold": 0.0022565651549393286,
+                "iq_angle": -2.980448168861428,
                 "mixer_drive_g": 0.0,
                 "mixer_drive_phi": 0.0,
                 "mixer_readout_g": 0.0,
@@ -1688,9 +1688,9 @@
             },
             "D4": {
                 "bare_resonator_frequency": 0,
-                "readout_frequency": 0,
-                "drive_frequency": 6249324670,
-                "anharmonicity": -200000000,
+                "readout_frequency": 7704602807,
+                "drive_frequency": 6260032162,
+                "anharmonicity": -211000000,
                 "sweetspot": 0,
                 "asymmetry": 0.0,
                 "crosstalk_matrix": {
@@ -1708,10 +1708,10 @@
                     "D1": 0.0,
                     "D2": 0.0,
                     "D3": 0.0,
-                    "D4": 0.7885346478252454,
+                    "D4": 0.31930898823471515,
                     "D5": 0.0
                 },
-                "Ec": 0.0,
+                "Ec": 211000000,
                 "Ej": 0.0,
                 "g": 0.0,
                 "assignment_fidelity": 0.5003,
@@ -1744,9 +1744,9 @@
             "D5": {
                 "bare_resonator_frequency": 0,
                 "readout_frequency": 0,
-                "drive_frequency": 5526500884,
-                "anharmonicity": -200000000,
-                "sweetspot": 0,
+                "drive_frequency": 5421335411,
+                "anharmonicity": -211000000,
+                "sweetspot": -0.04,
                 "asymmetry": 0.0,
                 "crosstalk_matrix": {
                     "A1": 0.0,
@@ -1764,13 +1764,13 @@
                     "D2": 0.0,
                     "D3": 0.0,
                     "D4": 0.0,
-                    "D5": 1.0
+                    "D5": 0.8971724416286263
                 },
-                "Ec": 0.0,
+                "Ec": 211000000,
                 "Ej": 0.0,
                 "g": 0.0,
-                "assignment_fidelity": 0.9626186973385048,
-                "readout_fidelity": 0.9252373946770096,
+                "assignment_fidelity": 0.9767472761094871,
+                "readout_fidelity": 0.9534945522189743,
                 "gate_fidelity": 0.0,
                 "effective_temperature": 0.0,
                 "peak_voltage": 0,
@@ -1782,15 +1782,15 @@
                 "state0_voltage": 0,
                 "state1_voltage": 0,
                 "mean_gnd_states": [
-                    0.0007246170853040929,
-                    -0.0016468244618507804
+                    0.0011620101565532517,
+                    -0.000599920281137028
                 ],
                 "mean_exc_states": [
-                    0.00317411347217255,
-                    -0.004417651383111833
+                    0.003313310505733698,
+                    -0.001908551292741929
                 ],
-                "threshold": 0.0033522577119041714,
-                "iq_angle": 0.8468743612250454,
+                "threshold": 0.0025593424931173144,
+                "iq_angle": 0.5464984071797813,
                 "mixer_drive_g": 0.0,
                 "mixer_drive_phi": 0.0,
                 "mixer_readout_g": 0.0,


### PR DESCRIPTION
Sweetspot recalibration for [D1](http://login.qrccluster.com:9000/6M7lmyJhRpGaIn681nyaDg==), [D2](http://login.qrccluster.com:9000/lZq7gzXNS-uNPwk7GjvZZg==) and [D3](http://login.qrccluster.com:9000/P0sj2j9FTqy7MulpipmzUw==).
By increasing the drive power now I've been able to address also [D5](http://login.qrccluster.com:9000/nxoGZJ_1SWuKY-cHzgif5A==). Despite achieving 98% readout fidelity T2 looks weird.