### PR TITLE
Recalibration of line B of qw11q

### DIFF
--- a/qw11q/parameters.json
+++ b/qw11q/parameters.json
@@ -504,7 +504,7 @@
                 },
                 "MZ": {
                     "duration": 2000,
-                    "amplitude": 0.00475,
+                    "amplitude": 0.0045,
                     "shape": "Rectangular()",
                     "frequency": 7147580000,
                     "relative_start": 0,
@@ -562,7 +562,7 @@
                 },
                 "MZ": {
                     "duration": 2000,
-                    "amplitude": 0.0025,
+                    "amplitude": 0.002,
                     "shape": "Rectangular()",
                     "frequency": 7494690000,
                     "relative_start": 0,
@@ -620,7 +620,7 @@
                 },
                 "MZ": {
                     "duration": 2000,
-                    "amplitude": 0.0038,
+                    "amplitude": 0.0055,
                     "shape": "Rectangular()",
                     "frequency": 7648690000,
                     "relative_start": 0,
@@ -1263,8 +1263,8 @@
                 "Ec": 0.0,
                 "Ej": 0.0,
                 "g": 0.0,
-                "assignment_fidelity": 0.7949712451517988,
-                "readout_fidelity": 0.5899424903035977,
+                "assignment_fidelity": 0.9492443493379699,
+                "readout_fidelity": 0.8984886986759396,
                 "gate_fidelity": 0.0,
                 "effective_temperature": 0.0,
                 "peak_voltage": 0,
@@ -1276,15 +1276,15 @@
                 "state0_voltage": 0,
                 "state1_voltage": 0,
                 "mean_gnd_states": [
-                    0.002521354080664736,
-                    0.0011407760847530735
+                    -0.00034164770532443486,
+                    -0.001575406286709489
                 ],
                 "mean_exc_states": [
-                    0.004708517654699901,
-                    0.0019710127987197746
+                    -0.0006423146648650599,
+                    -0.003594458352296576
                 ],
-                "threshold": 0.004224068524466672,
-                "iq_angle": -0.3627932078234494,
+                "threshold": 0.002598883910170167,
+                "iq_angle": 1.7186248945454914,
                 "mixer_drive_g": 0.0,
                 "mixer_drive_phi": 0.0,
                 "mixer_readout_g": 0.0,
@@ -1318,8 +1318,8 @@
                 "Ec": 0.0,
                 "Ej": 0.0,
                 "g": 0.0,
-                "assignment_fidelity": 0.9697739735187909,
-                "readout_fidelity": 0.9395479470375819,
+                "assignment_fidelity": 0.9734519192189381,
+                "readout_fidelity": 0.9469038384378762,
                 "gate_fidelity": 0.0,
                 "effective_temperature": 0.0,
                 "peak_voltage": 0,
@@ -1331,15 +1331,15 @@
                 "state0_voltage": 0,
                 "state1_voltage": 0,
                 "mean_gnd_states": [
-                    0.002962895908837272,
-                    -0.00836534167227792
+                    -0.0028561167052518523,
+                    0.0002900484093172379
                 ],
                 "mean_exc_states": [
-                    0.007515861854202307,
-                    -0.005636529990265008
+                    -0.005815198722969199,
+                    -0.0005899232049804329
                 ],
-                "threshold": 0.00046176565156542655,
-                "iq_angle": -0.5399400554077516,
+                "threshold": 0.004083141197965627,
+                "iq_angle": 2.8525413196324956,
                 "mixer_drive_g": 0.0,
                 "mixer_drive_phi": 0.0,
                 "mixer_readout_g": 0.0,
@@ -1373,8 +1373,8 @@
                 "Ec": 0.0,
                 "Ej": 0.0,
                 "g": 0.0,
-                "assignment_fidelity": 0.9380098970175204,
-                "readout_fidelity": 0.8760197940350407,
+                "assignment_fidelity": 0.9334626186973385,
+                "readout_fidelity": 0.866925237394677,
                 "gate_fidelity": 0.0,
                 "effective_temperature": 0.0,
                 "peak_voltage": 0,
@@ -1386,15 +1386,15 @@
                 "state0_voltage": 0,
                 "state1_voltage": 0,
                 "mean_gnd_states": [
-                    0.0010095272378117801,
-                    -0.002854906497928004
+                    0.00038322524646566727,
+                    -0.0010505920447132838
                 ],
                 "mean_exc_states": [
-                    0.005232764963771596,
-                    -0.003024815478230983
+                    0.0020140426534094626,
+                    -0.002260110328182971
                 ],
-                "threshold": 0.0028580991350093806,
-                "iq_angle": 0.04021023874376396,
+                "threshold": 0.0020246799681617475,
+                "iq_angle": 0.6381445773659398,
                 "mixer_drive_g": 0.0,
                 "mixer_drive_phi": 0.0,
                 "mixer_readout_g": 0.0,
@@ -1428,8 +1428,8 @@
                 "Ec": 0.0,
                 "Ej": 0.0,
                 "g": 0.0,
-                "assignment_fidelity": 0.5173866524006955,
-                "readout_fidelity": 0.03477330480139096,
+                "assignment_fidelity": 0.5655343052026214,
+                "readout_fidelity": 0.13106861040524276,
                 "gate_fidelity": 0.0,
                 "effective_temperature": 0.0,
                 "peak_voltage": 0,
@@ -1441,15 +1441,15 @@
                 "state0_voltage": 0,
                 "state1_voltage": 0,
                 "mean_gnd_states": [
-                    -0.0008219981539579017,
-                    -0.0011411481809896562
+                    0.0002666699759356126,
+                    0.0008667278071714655
                 ],
                 "mean_exc_states": [
-                    -0.0008399743769630257,
-                    -0.0011408577847643398
+                    0.0002870929246959926,
+                    0.0008918736630723616
                 ],
-                "threshold": 0.001516972228784563,
-                "iq_angle": -3.125439595856625,
+                "threshold": 0.0015556340926721676,
+                "iq_angle": -0.8886728542200425,
                 "mixer_drive_g": 0.0,
                 "mixer_drive_phi": 0.0,
                 "mixer_readout_g": 0.0,
@@ -1483,8 +1483,8 @@
                 "Ec": 0.0,
                 "Ej": 0.0,
                 "g": 0.0,
-                "assignment_fidelity": 0.961348134278454,
-                "readout_fidelity": 0.9226962685569079,
+                "assignment_fidelity": 0.9511167580580446,
+                "readout_fidelity": 0.9022335161160894,
                 "gate_fidelity": 0.0,
                 "effective_temperature": 0.0,
                 "peak_voltage": 0,
@@ -1496,15 +1496,15 @@
                 "state0_voltage": 0,
                 "state1_voltage": 0,
                 "mean_gnd_states": [
-                    0.0008883115944552736,
-                    0.00047225003836003765
+                    8.193634189967381e-05,
+                    -0.001271528938729982
                 ],
                 "mean_exc_states": [
-                    0.0027557740193988865,
-                    0.0029217183397617255
+                    -0.0004601266991929509,
+                    -0.0037592269258016377
                 ],
-                "threshold": 0.002430372555952587,
-                "iq_angle": -0.9194094891610921,
+                "threshold": 0.0022049688740333117,
+                "iq_angle": 1.7853402621357506,
                 "mixer_drive_g": 0.0,
                 "mixer_drive_phi": 0.0,
                 "mixer_readout_g": 0.0,

--- a/qw11q/parameters.json
+++ b/qw11q/parameters.json
@@ -515,7 +515,7 @@
             "B2": {
                 "RX": {
                     "duration": 40,
-                    "amplitude": 0.052,
+                    "amplitude": 0.05035328752923147,
                     "shape": "Gaussian(5)",
                     "frequency": 5972559992,
                     "relative_start": 0,
@@ -544,7 +544,7 @@
             "B3": {
                 "RX": {
                     "duration": 40,
-                    "amplitude": 0.067,
+                    "amplitude": 0.0646052967713636,
                     "shape": "Gaussian(5)",
                     "frequency": 5682974086,
                     "relative_start": 0,
@@ -602,7 +602,7 @@
             "B5": {
                 "RX": {
                     "duration": 40,
-                    "amplitude": 0.064,
+                    "amplitude": 0.06265399939419702,
                     "shape": "Gaussian(5)",
                     "frequency": 5742812934,
                     "relative_start": 0,

--- a/qw11q/parameters.json
+++ b/qw11q/parameters.json
@@ -488,7 +488,7 @@
                     "duration": 40,
                     "amplitude": 0.06,
                     "shape": "Gaussian(5)",
-                    "frequency": 5003775000,
+                    "frequency": 4999432081,
                     "relative_start": 0,
                     "phase": 0,
                     "type": "qd"
@@ -517,7 +517,7 @@
                     "duration": 40,
                     "amplitude": 0.052,
                     "shape": "Gaussian(5)",
-                    "frequency": 5972729000,
+                    "frequency": 5972559992,
                     "relative_start": 0,
                     "phase": 0,
                     "type": "qd"
@@ -546,7 +546,7 @@
                     "duration": 40,
                     "amplitude": 0.067,
                     "shape": "Gaussian(5)",
-                    "frequency": 5683533000,
+                    "frequency": 5682974086,
                     "relative_start": 0,
                     "phase": 0,
                     "type": "qd"
@@ -575,7 +575,7 @@
                     "duration": 40,
                     "amplitude": 0.066,
                     "shape": "Gaussian(5)",
-                    "frequency": 6482820000,
+                    "frequency": 6482264484,
                     "relative_start": 0,
                     "phase": 0,
                     "type": "qd"
@@ -604,7 +604,7 @@
                     "duration": 40,
                     "amplitude": 0.064,
                     "shape": "Gaussian(5)",
-                    "frequency": 5742661000,
+                    "frequency": 5742812934,
                     "relative_start": 0,
                     "phase": 0,
                     "type": "qd"
@@ -1238,7 +1238,7 @@
             "B1": {
                 "bare_resonator_frequency": 0,
                 "readout_frequency": 0,
-                "drive_frequency": 0,
+                "drive_frequency": 4999432081,
                 "anharmonicity": -200000000,
                 "sweetspot": 0.05,
                 "asymmetry": 0.0,
@@ -1263,8 +1263,8 @@
                 "Ec": 0.0,
                 "Ej": 0.0,
                 "g": 0.0,
-                "assignment_fidelity": 0.9492443493379699,
-                "readout_fidelity": 0.8984886986759396,
+                "assignment_fidelity": 0.9620837234184834,
+                "readout_fidelity": 0.9241674468369667,
                 "gate_fidelity": 0.0,
                 "effective_temperature": 0.0,
                 "peak_voltage": 0,
@@ -1276,15 +1276,15 @@
                 "state0_voltage": 0,
                 "state1_voltage": 0,
                 "mean_gnd_states": [
-                    -0.00034164770532443486,
-                    -0.001575406286709489
+                    -0.0003348098753115986,
+                    -0.0015926787355637654
                 ],
                 "mean_exc_states": [
-                    -0.0006423146648650599,
-                    -0.003594458352296576
+                    -0.0006714647958921816,
+                    -0.0036773822062695044
                 ],
-                "threshold": 0.002598883910170167,
-                "iq_angle": 1.7186248945454914,
+                "threshold": 0.0024950592990639025,
+                "iq_angle": 1.7309022619162402,
                 "mixer_drive_g": 0.0,
                 "mixer_drive_phi": 0.0,
                 "mixer_readout_g": 0.0,
@@ -1293,7 +1293,7 @@
             "B2": {
                 "bare_resonator_frequency": 0,
                 "readout_frequency": 0,
-                "drive_frequency": 0,
+                "drive_frequency": 5972559992,
                 "anharmonicity": -200000000,
                 "sweetspot": 0.315,
                 "asymmetry": 0.0,
@@ -1318,8 +1318,8 @@
                 "Ec": 0.0,
                 "Ej": 0.0,
                 "g": 0.0,
-                "assignment_fidelity": 0.9734519192189381,
-                "readout_fidelity": 0.9469038384378762,
+                "assignment_fidelity": 0.9731844322589274,
+                "readout_fidelity": 0.9463688645178547,
                 "gate_fidelity": 0.0,
                 "effective_temperature": 0.0,
                 "peak_voltage": 0,
@@ -1331,15 +1331,15 @@
                 "state0_voltage": 0,
                 "state1_voltage": 0,
                 "mean_gnd_states": [
-                    -0.0028561167052518523,
-                    0.0002900484093172379
+                    -0.002858795688124741,
+                    0.00030229810318794083
                 ],
                 "mean_exc_states": [
-                    -0.005815198722969199,
-                    -0.0005899232049804329
+                    -0.005860800348781273,
+                    -0.0005469252088219147
                 ],
-                "threshold": 0.004083141197965627,
-                "iq_angle": 2.8525413196324956,
+                "threshold": 0.004151870299922073,
+                "iq_angle": 2.8659103223035074,
                 "mixer_drive_g": 0.0,
                 "mixer_drive_phi": 0.0,
                 "mixer_readout_g": 0.0,
@@ -1348,7 +1348,7 @@
             "B3": {
                 "bare_resonator_frequency": 0,
                 "readout_frequency": 0,
-                "drive_frequency": 0,
+                "drive_frequency": 5682974086,
                 "anharmonicity": -200000000,
                 "sweetspot": -0.29,
                 "asymmetry": 0.0,
@@ -1373,8 +1373,8 @@
                 "Ec": 0.0,
                 "Ej": 0.0,
                 "g": 0.0,
-                "assignment_fidelity": 0.9334626186973385,
-                "readout_fidelity": 0.866925237394677,
+                "assignment_fidelity": 0.935602514377424,
+                "readout_fidelity": 0.8712050287548482,
                 "gate_fidelity": 0.0,
                 "effective_temperature": 0.0,
                 "peak_voltage": 0,
@@ -1386,15 +1386,15 @@
                 "state0_voltage": 0,
                 "state1_voltage": 0,
                 "mean_gnd_states": [
-                    0.00038322524646566727,
-                    -0.0010505920447132838
+                    0.0003577804604648482,
+                    -0.0010680472516647508
                 ],
                 "mean_exc_states": [
-                    0.0020140426534094626,
-                    -0.002260110328182971
+                    0.001996091153072581,
+                    -0.0023253249916001025
                 ],
-                "threshold": 0.0020246799681617475,
-                "iq_angle": 0.6381445773659398,
+                "threshold": 0.001998254742873806,
+                "iq_angle": 0.6545590640198508,
                 "mixer_drive_g": 0.0,
                 "mixer_drive_phi": 0.0,
                 "mixer_readout_g": 0.0,
@@ -1403,7 +1403,7 @@
             "B4": {
                 "bare_resonator_frequency": 0,
                 "readout_frequency": 0,
-                "drive_frequency": 6249230083,
+                "drive_frequency": 6482264484,
                 "anharmonicity": -200000000,
                 "sweetspot": -0.45,
                 "asymmetry": 0.0,
@@ -1428,8 +1428,8 @@
                 "Ec": 0.0,
                 "Ej": 0.0,
                 "g": 0.0,
-                "assignment_fidelity": 0.5655343052026214,
-                "readout_fidelity": 0.13106861040524276,
+                "assignment_fidelity": 0.565601176942624,
+                "readout_fidelity": 0.13120235388524804,
                 "gate_fidelity": 0.0,
                 "effective_temperature": 0.0,
                 "peak_voltage": 0,
@@ -1441,15 +1441,15 @@
                 "state0_voltage": 0,
                 "state1_voltage": 0,
                 "mean_gnd_states": [
-                    0.0002666699759356126,
-                    0.0008667278071714655
+                    0.0002514652152193301,
+                    0.0008706577987797983
                 ],
                 "mean_exc_states": [
-                    0.0002870929246959926,
-                    0.0008918736630723616
+                    0.0002707630665931725,
+                    0.0008869950982303691
                 ],
-                "threshold": 0.0015556340926721676,
-                "iq_angle": -0.8886728542200425,
+                "threshold": 0.0015237825229430413,
+                "iq_angle": -0.7025089802515454,
                 "mixer_drive_g": 0.0,
                 "mixer_drive_phi": 0.0,
                 "mixer_readout_g": 0.0,
@@ -1458,7 +1458,7 @@
             "B5": {
                 "bare_resonator_frequency": 0,
                 "readout_frequency": 0,
-                "drive_frequency": 5526500884,
+                "drive_frequency": 5742812934,
                 "anharmonicity": -200000000,
                 "sweetspot": -0.04,
                 "asymmetry": 0.0,
@@ -1483,8 +1483,8 @@
                 "Ec": 0.0,
                 "Ej": 0.0,
                 "g": 0.0,
-                "assignment_fidelity": 0.9511167580580446,
-                "readout_fidelity": 0.9022335161160894,
+                "assignment_fidelity": 0.9504480406580179,
+                "readout_fidelity": 0.9008960813160358,
                 "gate_fidelity": 0.0,
                 "effective_temperature": 0.0,
                 "peak_voltage": 0,
@@ -1496,15 +1496,15 @@
                 "state0_voltage": 0,
                 "state1_voltage": 0,
                 "mean_gnd_states": [
-                    8.193634189967381e-05,
-                    -0.001271528938729982
+                    6.646783280908214e-05,
+                    -0.0012824479166171215
                 ],
                 "mean_exc_states": [
-                    -0.0004601266991929509,
-                    -0.0037592269258016377
+                    -0.0005029529478598744,
+                    -0.003761378213936622
                 ],
-                "threshold": 0.0022049688740333117,
-                "iq_angle": 1.7853402621357506,
+                "threshold": 0.0022595986619760146,
+                "iq_angle": 1.796583788884944,
                 "mixer_drive_g": 0.0,
                 "mixer_drive_phi": 0.0,
                 "mixer_readout_g": 0.0,

--- a/qw11q/parameters.json
+++ b/qw11q/parameters.json
@@ -488,7 +488,7 @@
                     "duration": 40,
                     "amplitude": 0.06,
                     "shape": "Gaussian(5)",
-                    "frequency": 4982202000,
+                    "frequency": 5003775000,
                     "relative_start": 0,
                     "phase": 0,
                     "type": "qd"
@@ -515,7 +515,7 @@
             "B2": {
                 "RX": {
                     "duration": 40,
-                    "amplitude": 0.05,
+                    "amplitude": 0.052,
                     "shape": "Gaussian(5)",
                     "frequency": 5972729000,
                     "relative_start": 0,
@@ -535,7 +535,7 @@
                     "duration": 2000,
                     "amplitude": 0.003,
                     "shape": "Rectangular()",
-                    "frequency": 7395194000,
+                    "frequency": 7395594000,
                     "relative_start": 0,
                     "phase": 0,
                     "type": "ro"
@@ -544,7 +544,7 @@
             "B3": {
                 "RX": {
                     "duration": 40,
-                    "amplitude": 0.066,
+                    "amplitude": 0.067,
                     "shape": "Gaussian(5)",
                     "frequency": 5683533000,
                     "relative_start": 0,
@@ -564,7 +564,7 @@
                     "duration": 2000,
                     "amplitude": 0.0025,
                     "shape": "Rectangular()",
-                    "frequency": 7494560000,
+                    "frequency": 7494690000,
                     "relative_start": 0,
                     "phase": 0,
                     "type": "ro"
@@ -591,9 +591,9 @@
                 },
                 "MZ": {
                     "duration": 2000,
-                    "amplitude": 0.00175,
+                    "amplitude": 0.003,
                     "shape": "Rectangular()",
-                    "frequency": 7711519000,
+                    "frequency": 7712069000,
                     "relative_start": 0,
                     "phase": 0,
                     "type": "ro"
@@ -602,7 +602,7 @@
             "B5": {
                 "RX": {
                     "duration": 40,
-                    "amplitude": 0.063,
+                    "amplitude": 0.064,
                     "shape": "Gaussian(5)",
                     "frequency": 5742661000,
                     "relative_start": 0,
@@ -1240,7 +1240,7 @@
                 "readout_frequency": 0,
                 "drive_frequency": 0,
                 "anharmonicity": -200000000,
-                "sweetspot": 0,
+                "sweetspot": 0.05,
                 "asymmetry": 0.0,
                 "crosstalk_matrix": {
                     "A1": 0.0,
@@ -1295,7 +1295,7 @@
                 "readout_frequency": 0,
                 "drive_frequency": 0,
                 "anharmonicity": -200000000,
-                "sweetspot": 0,
+                "sweetspot": 0.315,
                 "asymmetry": 0.0,
                 "crosstalk_matrix": {
                     "A1": 0.0,
@@ -1350,7 +1350,7 @@
                 "readout_frequency": 0,
                 "drive_frequency": 0,
                 "anharmonicity": -200000000,
-                "sweetspot": 0,
+                "sweetspot": -0.29,
                 "asymmetry": 0.0,
                 "crosstalk_matrix": {
                     "A1": 0.0,
@@ -1405,7 +1405,7 @@
                 "readout_frequency": 0,
                 "drive_frequency": 6249230083,
                 "anharmonicity": -200000000,
-                "sweetspot": 0,
+                "sweetspot": -0.45,
                 "asymmetry": 0.0,
                 "crosstalk_matrix": {
                     "A1": 0.0,
@@ -1460,7 +1460,7 @@
                 "readout_frequency": 0,
                 "drive_frequency": 5526500884,
                 "anharmonicity": -200000000,
-                "sweetspot": 0,
+                "sweetspot": -0.04,
                 "asymmetry": 0.0,
                 "crosstalk_matrix": {
                     "A1": 0.0,


### PR DESCRIPTION
Qubit | T1 (us) | T2 (us) | Assignment Fidelity | Gate infidelity (1e-3) |
-- | -- | -- | -- | -- 
B2 | 20 | 12 | 97% | 2.00 (0.02)
B3 | 24 | 21 | 94% | 1.61 (0.02)
B5 | 34 | 28 | 95% | 0.61 (0.03)

* Single shot: http://login.qrccluster.com:9000/V4wiVyGyTy2D5y394Q4mXw==
* Rabi amplitude: http://login.qrccluster.com:9000/sTG9-BnIRVS1QxSJd_RPqQ==
* T1: http://login.qrccluster.com:9000/8S6hIAl4Q0OqD8dlzc00SA==
* T2 B2: http://login.qrccluster.com:9000/KMN4NjxMQP2byzlSKd6QDQ==
* T2 B3: http://login.qrccluster.com:9000/5U0NfVToQti_SW-gR87KKg==
* T2 B5: http://login.qrccluster.com:9000/rbmarqg4TAmNSaF_tdFtTw==
* RB B2: http://login.qrccluster.com:9000/Dutn72szTrabOQsCSzgWLA==
* RB B3: http://login.qrccluster.com:9000/skFVeQiTSIWKWFDKcJEC4g==
* RB B5: http://login.qrccluster.com:9000/pJijci52SZmBQ-683EQjFw==