### PR TITLE
qw5q_platinum controlled with QM OPX1000 for qibolab 0.2

### DIFF
--- a/qw5q_platinum/parameters.json
+++ b/qw5q_platinum/parameters.json
@@ -1,0 +1,370 @@
+{
+    "settings": {
+        "nshots": 2048,
+        "relaxation_time": 100000
+    },
+    "configs": {
+        "qm/bounds": {
+            "kind": "bounds",
+            "waveforms": 40000.0,
+            "readout": 30,
+            "instructions": 1000000
+        },
+        "twpa": {
+            "kind": "oscillator",
+            "frequency": 6542230000.0,
+            "power": 1.42
+        },
+        "probe_lo": {
+            "kind": "octave-oscillator",
+            "frequency": 7550000000.0,
+            "power": -10.0,
+            "output_mode": "always_on"
+        },
+        "01/drive_lo": {
+            "kind": "octave-oscillator",
+            "frequency": 4900000000.0,
+            "power": 0.0,
+            "output_mode": "always_on"
+        },
+        "2/drive_lo": {
+            "kind": "octave-oscillator",
+            "frequency": 5700000000.0,
+            "power": 0.0,
+            "output_mode": "always_on"
+        },
+        "3/drive_lo": {
+            "kind": "octave-oscillator",
+            "frequency": 6500000000.0,
+            "power": 0.0,
+            "output_mode": "always_on"
+        },
+        "4/drive_lo": {
+            "kind": "octave-oscillator",
+            "frequency": 6500000000.0,
+            "power": 0.0,
+            "output_mode": "always_on"
+        },
+        "0/probe": {
+            "kind": "iq",
+            "frequency": 7202448936.0
+        },
+        "0/acquisition": {
+            "kind": "qm-acquisition",
+            "delay": 224.0,
+            "smearing": 0.0,
+            "threshold": 0.001806559973762099,
+            "iq_angle": -1.100165435889717,
+            "kernel": null,
+            "gain": 10,
+            "offset": 0.0
+        },
+        "0/drive": {
+            "kind": "iq",
+            "frequency": 4773401847.0
+        },
+        "0/flux": {
+            "kind": "opx-output",
+            "offset": 0.26841555262486466,
+            "output_mode": "amplified"
+        },
+        "1/probe": {
+            "kind": "iq",
+            "frequency": 7332334801.0
+        },
+        "1/acquisition": {
+            "kind": "qm-acquisition",
+            "delay": 224.0,
+            "smearing": 0.0,
+            "threshold": 0.001806559973762099,
+            "iq_angle": -1.100165435889717,
+            "kernel": null,
+            "gain": 10,
+            "offset": 0.0
+        },
+        "1/drive": {
+            "kind": "iq",
+            "frequency": 4808384394.0
+        },
+        "1/flux": {
+            "kind": "opx-output",
+            "offset": -0.18,
+            "output_mode": "amplified"
+        },
+        "2/probe": {
+            "kind": "iq",
+            "frequency": 7493204662.0
+        },
+        "2/acquisition": {
+            "kind": "qm-acquisition",
+            "delay": 224.0,
+            "smearing": 0.0,
+            "threshold": 0.001806559973762099,
+            "iq_angle": -1.100165435889717,
+            "kernel": null,
+            "gain": 10,
+            "offset": 0.0
+        },
+        "2/drive": {
+            "kind": "iq",
+            "frequency": 5512171486.0
+        },
+        "2/flux": {
+            "kind": "opx-output",
+            "offset": 0.4812934537050486,
+            "output_mode": "amplified"
+        },
+        "3/probe": {
+            "kind": "iq",
+            "frequency": 7660383000.0
+        },
+        "3/acquisition": {
+            "kind": "qm-acquisition",
+            "delay": 224.0,
+            "smearing": 0.0,
+            "threshold": 0.001806559973762099,
+            "iq_angle": -1.100165435889717,
+            "kernel": null,
+            "gain": 10,
+            "offset": 0.0
+        },
+        "3/drive": {
+            "kind": "iq",
+            "frequency": 6329296235.0
+        },
+        "3/flux": {
+            "kind": "opx-output",
+            "offset": -0.581,
+            "output_mode": "amplified"
+        },
+        "4/probe": {
+            "kind": "iq",
+            "frequency": 7793718235.0
+        },
+        "4/acquisition": {
+            "kind": "qm-acquisition",
+            "delay": 224.0,
+            "smearing": 0.0,
+            "threshold": 0.001806559973762099,
+            "iq_angle": -1.100165435889717,
+            "kernel": null,
+            "gain": 10,
+            "offset": 0.0
+        },
+        "4/drive": {
+            "kind": "iq",
+            "frequency": 6236225900.0
+        },
+        "4/flux": {
+            "kind": "opx-output",
+            "offset": -0.04822291721348779,
+            "output_mode": "amplified"
+        }
+    },
+    "native_gates": {
+        "single_qubit": {
+            "0": {
+                "RX": [
+                    [
+                        "0/drive",
+                        {
+                            "kind": "pulse",
+                            "duration": 40.0,
+                            "amplitude": 0.176,
+                            "envelope": {
+                                "kind": "gaussian",
+                                "rel_sigma": 0.2
+                            },
+                            "relative_phase": 0.0
+                        }
+                    ]
+                ],
+                "RX12": null,
+                "MZ": [
+                    [
+                        "0/acquisition",
+                        {
+                            "kind": "readout",
+                            "acquisition": {
+                                "kind": "acquisition",
+                                "duration": 2000.0
+                            },
+                            "probe": {
+                                "kind": "pulse",
+                                "duration": 2000.0,
+                                "amplitude": 0.012,
+                                "envelope": {
+                                    "kind": "rectangular"
+                                },
+                                "relative_phase": 0.0
+                            }
+                        }
+                    ]
+                ],
+                "CP": null
+            },
+            "1": {
+                "RX": [
+                    [
+                        "1/drive",
+                        {
+                            "kind": "pulse",
+                            "duration": 40.0,
+                            "amplitude": 0.0332,
+                            "envelope": {
+                                "kind": "gaussian",
+                                "rel_sigma": 0.2
+                            },
+                            "relative_phase": 0.0
+                        }
+                    ]
+                ],
+                "RX12": null,
+                "MZ": [
+                    [
+                        "1/acquisition",
+                        {
+                            "kind": "readout",
+                            "acquisition": {
+                                "kind": "acquisition",
+                                "duration": 2000.0
+                            },
+                            "probe": {
+                                "kind": "pulse",
+                                "duration": 2000.0,
+                                "amplitude": 0.002,
+                                "envelope": {
+                                    "kind": "rectangular"
+                                },
+                                "relative_phase": 0.0
+                            }
+                        }
+                    ]
+                ],
+                "CP": null
+            },
+            "2": {
+                "RX": [
+                    [
+                        "2/drive",
+                        {
+                            "kind": "pulse",
+                            "duration": 40.0,
+                            "amplitude": 0.0332,
+                            "envelope": {
+                                "kind": "gaussian",
+                                "rel_sigma": 0.2
+                            },
+                            "relative_phase": 0.0
+                        }
+                    ]
+                ],
+                "RX12": null,
+                "MZ": [
+                    [
+                        "2/acquisition",
+                        {
+                            "kind": "readout",
+                            "acquisition": {
+                                "kind": "acquisition",
+                                "duration": 2000.0
+                            },
+                            "probe": {
+                                "kind": "pulse",
+                                "duration": 2000.0,
+                                "amplitude": 0.004,
+                                "envelope": {
+                                    "kind": "rectangular"
+                                },
+                                "relative_phase": 0.0
+                            }
+                        }
+                    ]
+                ],
+                "CP": null
+            },
+            "3": {
+                "RX": [
+                    [
+                        "3/drive",
+                        {
+                            "kind": "pulse",
+                            "duration": 40.0,
+                            "amplitude": 0.136,
+                            "envelope": {
+                                "kind": "gaussian",
+                                "rel_sigma": 0.2
+                            },
+                            "relative_phase": 0.0
+                        }
+                    ]
+                ],
+                "RX12": null,
+                "MZ": [
+                    [
+                        "3/acquisition",
+                        {
+                            "kind": "readout",
+                            "acquisition": {
+                                "kind": "acquisition",
+                                "duration": 2000.0
+                            },
+                            "probe": {
+                                "kind": "pulse",
+                                "duration": 2000.0,
+                                "amplitude": 0.014,
+                                "envelope": {
+                                    "kind": "rectangular"
+                                },
+                                "relative_phase": 0.0
+                            }
+                        }
+                    ]
+                ],
+                "CP": null
+            },
+            "4": {
+                "RX": [
+                    [
+                        "4/drive",
+                        {
+                            "kind": "pulse",
+                            "duration": 40.0,
+                            "amplitude": 0.159,
+                            "envelope": {
+                                "kind": "gaussian",
+                                "rel_sigma": 0.2
+                            },
+                            "relative_phase": 0.0
+                        }
+                    ]
+                ],
+                "RX12": null,
+                "MZ": [
+                    [
+                        "4/acquisition",
+                        {
+                            "kind": "readout",
+                            "acquisition": {
+                                "kind": "acquisition",
+                                "duration": 2000.0
+                            },
+                            "probe": {
+                                "kind": "pulse",
+                                "duration": 2000.0,
+                                "amplitude": 0.006,
+                                "envelope": {
+                                    "kind": "rectangular"
+                                },
+                                "relative_phase": 0.0
+                            }
+                        }
+                    ]
+                ],
+                "CP": null
+            }
+        },
+        "coupler": {},
+        "two_qubit": {}
+    }
+}

--- a/qw5q_platinum/parameters.json
+++ b/qw5q_platinum/parameters.json
@@ -53,8 +53,8 @@
             "kind": "qm-acquisition",
             "delay": 224.0,
             "smearing": 0.0,
-            "threshold": 0.0050746640940701245,
-            "iq_angle": -0.315736905002615,
+            "threshold": 0.005134536511341071,
+            "iq_angle": -0.29740896436378317,
             "kernel": null,
             "gain": 10,
             "offset": 0.0
@@ -101,8 +101,8 @@
             "kind": "qm-acquisition",
             "delay": 224.0,
             "smearing": 0.0,
-            "threshold": 0.0031103401074213366,
-            "iq_angle": 1.5542188761280658,
+            "threshold": 0.0034120167301051126,
+            "iq_angle": 1.5704503406631587,
             "kernel": null,
             "gain": 10,
             "offset": 0.0
@@ -125,8 +125,8 @@
             "kind": "qm-acquisition",
             "delay": 224.0,
             "smearing": 0.0,
-            "threshold": 0.005024984605102332,
-            "iq_angle": 0.26809260114131156,
+            "threshold": 0.005144906282110747,
+            "iq_angle": 0.23761955385072117,
             "kernel": null,
             "gain": 10,
             "offset": 0.0
@@ -149,8 +149,8 @@
             "kind": "qm-acquisition",
             "delay": 224.0,
             "smearing": 0.0,
-            "threshold": 0.0016615786465084248,
-            "iq_angle": 2.3622151192773138,
+            "threshold": 0.001704547130855065,
+            "iq_angle": 2.3229800598289256,
             "kernel": null,
             "gain": 10,
             "offset": 0.0
@@ -255,7 +255,7 @@
                         {
                             "kind": "pulse",
                             "duration": 40.0,
-                            "amplitude": 0.0332,
+                            "amplitude": 0.1025,
                             "envelope": {
                                 "kind": "gaussian",
                                 "rel_sigma": 0.2

--- a/qw5q_platinum/parameters.json
+++ b/qw5q_platinum/parameters.json
@@ -53,8 +53,8 @@
             "kind": "qm-acquisition",
             "delay": 224.0,
             "smearing": 0.0,
-            "threshold": 0.001806559973762099,
-            "iq_angle": -1.100165435889717,
+            "threshold": 0.0050746640940701245,
+            "iq_angle": -0.315736905002615,
             "kernel": null,
             "gain": 10,
             "offset": 0.0
@@ -66,6 +66,7 @@
         "0/flux": {
             "kind": "opx-output",
             "offset": 0.26841555262486466,
+            "filter": {},
             "output_mode": "amplified"
         },
         "1/probe": {
@@ -89,6 +90,7 @@
         "1/flux": {
             "kind": "opx-output",
             "offset": -0.18,
+            "filter": {},
             "output_mode": "amplified"
         },
         "2/probe": {
@@ -99,8 +101,8 @@
             "kind": "qm-acquisition",
             "delay": 224.0,
             "smearing": 0.0,
-            "threshold": 0.001806559973762099,
-            "iq_angle": -1.100165435889717,
+            "threshold": 0.0031103401074213366,
+            "iq_angle": 1.5542188761280658,
             "kernel": null,
             "gain": 10,
             "offset": 0.0
@@ -112,6 +114,7 @@
         "2/flux": {
             "kind": "opx-output",
             "offset": 0.4812934537050486,
+            "filter": {},
             "output_mode": "amplified"
         },
         "3/probe": {
@@ -122,8 +125,8 @@
             "kind": "qm-acquisition",
             "delay": 224.0,
             "smearing": 0.0,
-            "threshold": 0.001806559973762099,
-            "iq_angle": -1.100165435889717,
+            "threshold": 0.005024984605102332,
+            "iq_angle": 0.26809260114131156,
             "kernel": null,
             "gain": 10,
             "offset": 0.0
@@ -135,6 +138,7 @@
         "3/flux": {
             "kind": "opx-output",
             "offset": -0.581,
+            "filter": {},
             "output_mode": "amplified"
         },
         "4/probe": {
@@ -145,8 +149,8 @@
             "kind": "qm-acquisition",
             "delay": 224.0,
             "smearing": 0.0,
-            "threshold": 0.001806559973762099,
-            "iq_angle": -1.100165435889717,
+            "threshold": 0.0016615786465084248,
+            "iq_angle": 2.3622151192773138,
             "kernel": null,
             "gain": 10,
             "offset": 0.0
@@ -158,6 +162,7 @@
         "4/flux": {
             "kind": "opx-output",
             "offset": -0.04822291721348779,
+            "filter": {},
             "output_mode": "amplified"
         }
     },

--- a/qw5q_platinum/platform.py
+++ b/qw5q_platinum/platform.py
@@ -19,10 +19,7 @@ ConfigKinds.extend([QmConfigs])
 
 
 def create():
-    """Line D of QuantWare 21q-chip controlled with Quantum Machines.
-
-    Qubits D1, D2, D3 have been tested to work.
-    """
+    """QuantWare 5q-chip controlled with Quantum Machines OPX1000 and Octaves."""
     qubits = {i: Qubit.default(i) for i in range(5)}
 
     # Create channels and connect to instrument ports

--- a/qw5q_platinum/platform.py
+++ b/qw5q_platinum/platform.py
@@ -1,0 +1,77 @@
+import pathlib
+
+from qibolab import (
+    AcquisitionChannel,
+    Channel,
+    ConfigKinds,
+    DcChannel,
+    IqChannel,
+    Platform,
+    Qubit,
+)
+from qibolab.instruments.qm import Octave, QmConfigs, QmController
+from qibolab.instruments.rohde_schwarz import SGS100A
+
+FOLDER = pathlib.Path(__file__).parent
+
+# Register QM-specific configurations for parameters loading
+ConfigKinds.extend([QmConfigs])
+
+
+def create():
+    """Line D of QuantWare 21q-chip controlled with Quantum Machines.
+
+    Qubits D1, D2, D3 have been tested to work.
+    """
+    qubits = {i: Qubit.default(i) for i in range(5)}
+
+    # Create channels and connect to instrument ports
+    # Readout
+    channels = {}
+    for q in qubits.values():
+        channels[q.probe] = IqChannel(
+            device="octave2", path="1", mixer=None, lo="probe_lo"
+        )
+    # Acquire
+    for q in qubits.values():
+        channels[q.acquisition] = AcquisitionChannel(
+            device="octave2", path="1", twpa_pump="twpa", probe=q.probe
+        )
+    # Drive
+    channels[qubits[0].drive] = IqChannel(
+        device="octave1", path="2", mixer=None, lo="01/drive_lo"
+    )
+    channels[qubits[1].drive] = IqChannel(
+        device="octave1", path="3", mixer=None, lo="01/drive_lo"
+    )
+    channels[qubits[2].drive] = IqChannel(
+        device="octave1", path="1", mixer=None, lo="2/drive_lo"
+    )
+    channels[qubits[3].drive] = IqChannel(
+        device="octave1", path="4", mixer=None, lo="3/drive_lo"
+    )
+    channels[qubits[4].drive] = IqChannel(
+        device="octave2", path="2", mixer=None, lo="4/drive_lo"
+    )
+    # Flux
+    channels[qubits[0].flux] = DcChannel(device="con1/4", path="4")
+    channels[qubits[1].flux] = DcChannel(device="con1/4", path="1")
+    channels[qubits[2].flux] = DcChannel(device="con1/4", path="3")
+    channels[qubits[3].flux] = DcChannel(device="con1/4", path="2")
+    channels[qubits[4].flux] = DcChannel(device="con1/4", path="5")
+
+    octaves = {
+        "octave1": Octave("octave1", port=11250, connectivity="con1/1"),
+        "octave2": Octave("octave2", port=11251, connectivity="con1/2"),
+    }
+    fems = {"con1/1": "LF", "con1/2": "LF", "con1/4": "LF"}
+    controller = QmController(
+        address="192.168.0.102:80",
+        octaves=octaves,
+        fems=fems,
+        channels=channels,
+        # calibration_path=FOLDER,
+        script_file_name="qua_script.py",
+    )
+    instruments = {"qm": controller, "twpa": SGS100A(address="192.168.0.38")}
+    return Platform.load(path=FOLDER, instruments=instruments, qubits=qubits)


### PR DESCRIPTION
Requires https://github.com/qiboteam/qibolab/pull/1068. Updated qibocal routines have been tested to work: http://login.qrccluster.com:9000/f5mxayd_QXOwM9TcgpvEBw==.