### PR TITLE
Support QM specific configs in the 0.2 platform upgrader

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -13,6 +13,8 @@ from qibolab._core.serialize import NdArray
 
 NONSERIAL = lambda: None
 """Raise an error if survives in the final object to be serialized."""
+QM_TIME_OF_FLIGHT = 224
+"""Default time of flight for QM platforms (in 0.1 this was hard-coded in platform.py)."""
 
 
 def channel_from_pulse(pulse: dict) -> dict:
@@ -34,7 +36,11 @@ def qm_configs(conf: dict, instruments: dict, instrument_channels: dict) -> dict
             kind = conf[channel]["kind"]
             if kind == "acquisition":
                 conf[channel].update(
-                    {"kind": "qm-acquisition", "gain": settings.get("gain", 0)}
+                    {
+                        "kind": "qm-acquisition",
+                        "delay": QM_TIME_OF_FLIGHT,
+                        "gain": settings.get("gain", 0),
+                    }
                 )
             elif kind == "dc":
                 conf[channel].update(

--- a/convert.py
+++ b/convert.py
@@ -156,7 +156,7 @@ def pulse(o: dict) -> dict:
         "duration": o["duration"],
         "amplitude": o["amplitude"],
         "envelope": envelope(o["shape"]),
-        "relative_phase": o.get("phase"),
+        "relative_phase": o.get("phase", 0.0),
     }
 
 

--- a/qw11q/connections.json
+++ b/qw11q/connections.json
@@ -1,0 +1,189 @@
+{
+    "kind": "qm",
+    "channels": {
+        "A1A4/drive_lo": {
+            "instrument": "octave4",
+            "port": "o2"
+        },
+        "A2A3/drive_lo": {
+            "instrument": "octave4",
+            "port": "o4"
+        },
+        "A5D5/drive_lo": {
+            "instrument": "octave6",
+            "port": "o2"
+        },
+        "A6D4/drive_lo": {
+            "instrument": "octave6",
+            "port": "o4"
+        },
+        "B1/drive_lo": {
+            "instrument": "octave2",
+            "port": "o2"
+        },
+        "B2/drive_lo": {
+            "instrument": "octave2",
+            "port": "o4"
+        },
+        "B3/drive_lo": {
+            "instrument": "octave3",
+            "port": "o1"
+        },
+        "B4/drive_lo": {
+            "instrument": "octave3",
+            "port": "o4"
+        },
+        "B5/drive_lo": {
+            "instrument": "octave3",
+            "port": "o3"
+        },
+        "D1/drive_lo": {
+            "instrument": "octave5",
+            "port": "o2"
+        },
+        "D2D3/drive_lo": {
+            "instrument": "octave5",
+            "port": "o4"
+        },
+        "A/probe_lo": {
+            "instrument": "octave4",
+            "port": "o1"
+        },
+        "B/probe_lo": {
+            "instrument": "octave2",
+            "port": "o1"
+        },
+        "D/probe_lo": {
+            "instrument": "octave5",
+            "port": "o1"
+        },
+        "A1/flux": {
+            "instrument": "con7",
+            "port": "o3"
+        },
+        "A2/flux": {
+            "instrument": "con7",
+            "port": "o4"
+        },
+        "A3/flux": {
+            "instrument": "con7",
+            "port": "o5"
+        },
+        "A4/flux": {
+            "instrument": "con7",
+            "port": "o6"
+        },
+        "A5/flux": {
+            "instrument": "con7",
+            "port": "o7"
+        },
+        "A6/flux": {
+            "instrument": "con7",
+            "port": "o8"
+        },
+        "B1/flux": {
+            "instrument": "con4",
+            "port": "o1"
+        },
+        "B2/flux": {
+            "instrument": "con4",
+            "port": "o2"
+        },
+        "B3/flux": {
+            "instrument": "con4",
+            "port": "o3"
+        },
+        "B4/flux": {
+            "instrument": "con4",
+            "port": "o4"
+        },
+        "B5/flux": {
+            "instrument": "con4",
+            "port": "o5"
+        },
+        "D1/flux": {
+            "instrument": "con9",
+            "port": "o3"
+        },
+        "D2/flux": {
+            "instrument": "con9",
+            "port": "o4"
+        },
+        "D3/flux": {
+            "instrument": "con9",
+            "port": "o5"
+        },
+        "D4/flux": {
+            "instrument": "con9",
+            "port": "o6"
+        },
+        "D5/flux": {
+            "instrument": "con9",
+            "port": "o7"
+        },
+        "A1/acquisition": {
+            "instrument": "con5",
+            "port": "i1"
+        },
+        "A2/acquisition": {
+            "instrument": "con5",
+            "port": "i1"
+        },
+        "A3/acquisition": {
+            "instrument": "con5",
+            "port": "i1"
+        },
+        "A4/acquisition": {
+            "instrument": "con5",
+            "port": "i1"
+        },
+        "A5/acquisition": {
+            "instrument": "con5",
+            "port": "i1"
+        },
+        "A6/acquisition": {
+            "instrument": "con5",
+            "port": "i1"
+        },
+        "B1/acquisition": {
+            "instrument": "con2",
+            "port": "i1"
+        },
+        "B2/acquisition": {
+            "instrument": "con2",
+            "port": "i1"
+        },
+        "B3/acquisition": {
+            "instrument": "con2",
+            "port": "i1"
+        },
+        "B4/acquisition": {
+            "instrument": "con2",
+            "port": "i1"
+        },
+        "B5/acquisition": {
+            "instrument": "con2",
+            "port": "i1"
+        },
+        "D1/acquisition": {
+            "instrument": "con6",
+            "port": "i1"
+        },
+        "D2/acquisition": {
+            "instrument": "con6",
+            "port": "i1"
+        },
+        "D3/acquisition": {
+            "instrument": "con6",
+            "port": "i1"
+        },
+        "D4/acquisition": {
+            "instrument": "con6",
+            "port": "i1"
+        },
+        "D5/acquisition": {
+            "instrument": "con6",
+            "port": "i1"
+        }
+    }
+}

--- a/qw5q_platinum/connections.json
+++ b/qw5q_platinum/connections.json
@@ -1,0 +1,70 @@
+{
+    "kind": "qm",
+    "channels": {
+        "01/drive_lo": {
+            "instrument": "octave1",
+            "port": "o2",
+            "output_mode": "always_on"
+        },
+        "2/drive_lo": {
+            "instrument": "octave1",
+            "port": "o1",
+            "output_mode": "always_on"
+        },
+        "3/drive_lo": {
+            "instrument": "octave1",
+            "port": "o4",
+            "output_mode": "always_on"
+        },
+        "4/drive_lo": {
+            "instrument": "octave2",
+            "port": "o2",
+            "output_mode": "always_on"
+        },
+        "probe_lo": {
+            "instrument": "octave2",
+            "port": "o1",
+            "output_mode": "always_on"
+        },
+        "0/flux": {
+            "instrument": "con1",
+            "port": "4/o4"
+        },
+        "1/flux": {
+            "instrument": "con1",
+            "port": "4/o1"
+        },
+        "2/flux": {
+            "instrument": "con1",
+            "port": "4/o3"
+        },
+        "3/flux": {
+            "instrument": "con1",
+            "port": "4/o2"
+        },
+        "4/flux": {
+            "instrument": "con1",
+            "port": "4/o5"
+        },
+        "0/acquisition": {
+            "instrument": "con1",
+            "port": "2/i1"
+        },
+        "1/acquisition": {
+            "instrument": "con1",
+            "port": "2/i1"
+        },
+        "2/acquisition": {
+            "instrument": "con1",
+            "port": "2/i1"
+        },
+        "3/acquisition": {
+            "instrument": "con1",
+            "port": "2/i1"
+        },
+        "4/acquisition": {
+            "instrument": "con1",
+            "port": "2/i1"
+        }
+    }
+}


### PR DESCRIPTION
In 0.1 the parameters of QM configs were stored as instrument settings, therefore we need a mapping between the 0.2 channels and 0.1 instrument ports. I added this in a new `connections.json` file to avoid making the upgrader dependable on qibolab versions.

Now the usage should be
```sh
python convert.py qw11q/parameters.json --connections qw11q/connections.json
```
in order to include the QM configs in the new parameters.

I have provided `connections.json` for qw11q and qw5q_platinum.