### PR TITLE
TWPA power - reduced - URGENT

### DIFF
--- a/qw11q/parameters.json
+++ b/qw11q/parameters.json
@@ -11,12 +11,12 @@
             "kind": "bounds"
         },
         "twpaB": {
-            "power": -2.75,
+            "power": -80,
             "frequency": 6488000000,
             "kind": "oscillator"
         },
         "twpaD": {
-            "power": -2.6,
+            "power": -80,
             "frequency": 6149000000,
             "kind": "oscillator"
         },


### PR DESCRIPTION
On the qw11q the lab installed a different TWPA which operates at a much lower power. As a safety feature I suggest to reduce the power to avoid possible damage of the twpa. Note that at the moment the TWPA is not calibrated and the purpose of this is to avoid any potential harm to the twpa.