### PR TITLE
Add missing dependencies in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,6 +21,7 @@ jobs:
           python -m venv testenv
           source testenv/bin/activate
           pip install pytest
+          pip install qcodes
           pip install qibolab-qm
       - name: Install and configure poetry
         if: ${{ matrix.version == 'main' }}
@@ -32,6 +33,10 @@ jobs:
         run: |
           python -m venv testenv
           source testenv/bin/activate
+          git clone https://github.com/qiboteam/qibolab
+          cd qibolab
+          poetry install --no-interaction --with tests --all-extras
+          cd ..
           git clone https://github.com/qiboteam/qibolab-qm
           cd qibolab-qm
           poetry install --no-interaction --with tests --all-extras

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,6 +38,7 @@ jobs:
             cd $lib
             poetry install --no-interaction --with tests --all-extras
             cd ..
+          done
       - name: Test platforms
         run: |
           source testenv/bin/activate

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,17 +32,12 @@ jobs:
         run: |
           python -m venv testenv
           source testenv/bin/activate
-          git clone https://github.com/qiboteam/qibolab
-          cd qibolab
-          poetry install --no-interaction --with tests --all-extras
-          cd ..
-          git clone https://github.com/qiboteam/qibolab-qm
-          cd qibolab-qm
-          poetry install --no-interaction --with tests --all-extras
-          cd ..
-          git clone https://github.com/qiboteam/qibolab-qblox
-          cd qibolab-qblox
-          poetry install --no-interaction --with tests --all-extras
+          for lib in qibolab-qm qibolab-qblox qibolab
+          do
+            git clone https://github.com/qiboteam/$lib
+            cd $lib
+            poetry install --no-interaction --with tests --all-extras
+            cd ..
       - name: Test platforms
         run: |
           source testenv/bin/activate

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
           python -m venv testenv
           source testenv/bin/activate
           pip install pytest
-          pip install qibolab[qblox,zh,qm,rfsoc]
+          pip install qibolab-qm
       - name: Install and configure poetry
         if: ${{ matrix.version == 'main' }}
         uses: snok/install-poetry@v1
@@ -32,8 +32,8 @@ jobs:
         run: |
           python -m venv testenv
           source testenv/bin/activate
-          git clone https://github.com/qiboteam/qibolab
-          cd qibolab
+          git clone https://github.com/qiboteam/qibolab-qm
+          cd qibolab-qm
           poetry install --no-interaction --with tests --all-extras
       - name: Test platforms
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,8 +21,7 @@ jobs:
           python -m venv testenv
           source testenv/bin/activate
           pip install pytest
-          pip install qcodes
-          pip install qibolab-qm
+          pip install qcodes qibolab-qm qibolab-qblox
       - name: Install and configure poetry
         if: ${{ matrix.version == 'main' }}
         uses: snok/install-poetry@v1
@@ -39,6 +38,10 @@ jobs:
           cd ..
           git clone https://github.com/qiboteam/qibolab-qm
           cd qibolab-qm
+          poetry install --no-interaction --with tests --all-extras
+          cd ..
+          git clone https://github.com/qiboteam/qibolab-qblox
+          cd qibolab-qblox
           poetry install --no-interaction --with tests --all-extras
       - name: Test platforms
         run: |


### PR DESCRIPTION
After the refactoring of dependencies in qibolab.
Note that this will only work for QM, as we have not created the qibolab-* repositories for other drivers. I also had to install `qcodes` manually, as it is needed to instantiate the R&S LOs used as TWPA pumps. I am not sure if there is a more elegant solution,