### PR TITLE
iqm5q controlled with Qblox (only qubit 0)

### DIFF
--- a/iqm5q/calibration.json
+++ b/iqm5q/calibration.json
@@ -1,0 +1,326 @@
+{
+    "single_qubits": {
+        "0": {
+            "resonator": {
+                "bare_frequency": 5221992000.0,
+                "dressed_frequency": 5226976330.0,
+                "depletion_time": null,
+                "bare_frequency_amplitude": null
+            },
+            "qubit": {
+                "frequency_01": 4106848222.0,
+                "frequency_12": null,
+                "maximum_frequency": null,
+                "asymmetry": null,
+                "sweetspot": 0.000899265657818477,
+                "flux_coefficients": null
+            },
+            "readout": {
+                "fidelity": 0.9024714323677916,
+                "coupling": null,
+                "effective_temperature": 0.050111630362627155,
+                "ground_state": [
+                    0.00023674344305659392,
+                    0.00015997535962154549
+                ],
+                "excited_state": [
+                    -0.001367023888916079,
+                    0.0008251503889269217
+                ],
+                "qudits_frequency": {}
+            },
+            "t1": [
+                23128.0,
+                null
+            ],
+            "t2": [
+                10680.0,
+                null
+            ],
+            "t2_spin_echo": [
+                27529.0,
+                null
+            ],
+            "rb_fidelity": [
+                0.0,
+                null
+            ]
+        },
+        "1": {
+            "resonator": {
+                "bare_frequency": 4927992000.0,
+                "dressed_frequency": 4928845888.0,
+                "depletion_time": null,
+                "bare_frequency_amplitude": null
+            },
+            "qubit": {
+                "frequency_01": 4264109688.0,
+                "frequency_12": null,
+                "maximum_frequency": null,
+                "asymmetry": null,
+                "sweetspot": 0.0023976004181763973,
+                "flux_coefficients": null
+            },
+            "readout": {
+                "fidelity": 0.7810619232312426,
+                "coupling": null,
+                "effective_temperature": null,
+                "ground_state": [
+                    0.00005834395194214067,
+                    0.00008677844703293782
+                ],
+                "excited_state": [
+                    -0.0018830868177225713,
+                    -0.0003548772384203413
+                ],
+                "qudits_frequency": {}
+            },
+            "t1": [
+                18407.0,
+                null
+            ],
+            "t2": [
+                11505.0,
+                null
+            ],
+            "t2_spin_echo": [
+                13542.0,
+                null
+            ],
+            "rb_fidelity": [
+                0.0,
+                null
+            ]
+        },
+        "2": {
+            "resonator": {
+                "bare_frequency": 6078000000.0,
+                "dressed_frequency": 6114827652.0,
+                "depletion_time": null,
+                "bare_frequency_amplitude": null
+            },
+            "qubit": {
+                "frequency_01": 4556619068.0,
+                "frequency_12": null,
+                "maximum_frequency": null,
+                "asymmetry": null,
+                "sweetspot": -0.008346954748958205,
+                "flux_coefficients": null
+            },
+            "readout": {
+                "fidelity": 0.8896616289955865,
+                "coupling": null,
+                "effective_temperature": null,
+                "ground_state": [
+                    -0.0041441307777274556,
+                    0.0000652283757053139
+                ],
+                "excited_state": [
+                    -0.005322162873072615,
+                    0.003875668773442831
+                ],
+                "qudits_frequency": {}
+            },
+            "t1": [
+                8507.0,
+                null
+            ],
+            "t2": [
+                3595.0,
+                null
+            ],
+            "t2_spin_echo": [
+                14121.0,
+                null
+            ],
+            "rb_fidelity": [
+                0.0,
+                null
+            ]
+        },
+        "3": {
+            "resonator": {
+                "bare_frequency": 5778500000.0,
+                "dressed_frequency": 5808431510.0,
+                "depletion_time": null,
+                "bare_frequency_amplitude": null
+            },
+            "qubit": {
+                "frequency_01": 4101313618.0,
+                "frequency_12": null,
+                "maximum_frequency": null,
+                "asymmetry": null,
+                "sweetspot": -0.06,
+                "flux_coefficients": null
+            },
+            "readout": {
+                "fidelity": 0.8701350809148054,
+                "coupling": null,
+                "effective_temperature": null,
+                "ground_state": [
+                    -0.002529545200411399,
+                    -0.007103022859003043
+                ],
+                "excited_state": [
+                    -0.005168027922569168,
+                    -0.004643851733279827
+                ],
+                "qudits_frequency": {}
+            },
+            "t1": [
+                23964.0,
+                null
+            ],
+            "t2": [
+                3255.0,
+                null
+            ],
+            "t2_spin_echo": [
+                5900.0,
+                null
+            ],
+            "rb_fidelity": [
+                0.0,
+                null
+            ]
+        },
+        "4": {
+            "resonator": {
+                "bare_frequency": 5516492000.0,
+                "dressed_frequency": 5532640418.0,
+                "depletion_time": null,
+                "bare_frequency_amplitude": null
+            },
+            "qubit": {
+                "frequency_01": 4358114655.0,
+                "frequency_12": null,
+                "maximum_frequency": null,
+                "asymmetry": null,
+                "sweetspot": -0.009373475164799153,
+                "flux_coefficients": null
+            },
+            "readout": {
+                "fidelity": 0.8579644242343185,
+                "coupling": null,
+                "effective_temperature": null,
+                "ground_state": [
+                    0.0006515258994429122,
+                    -0.0005329945732580831
+                ],
+                "excited_state": [
+                    0.0009039271961622637,
+                    -0.00232330085856834
+                ],
+                "qudits_frequency": {}
+            },
+            "t1": [
+                7030.0,
+                null
+            ],
+            "t2": [
+                9573.0,
+                null
+            ],
+            "t2_spin_echo": [
+                8313.0,
+                null
+            ],
+            "rb_fidelity": [
+                0.0,
+                null
+            ]
+        }
+    },
+    "two_qubits": {
+        "0-2": {
+            "rb_fidelity": [
+                0.0,
+                null
+            ],
+            "cz_fidelity": [
+                0.0,
+                null
+            ],
+            "coupling": null
+        },
+        "2-0": {
+            "rb_fidelity": [
+                0.0,
+                null
+            ],
+            "cz_fidelity": [
+                0.0,
+                null
+            ],
+            "coupling": null
+        },
+        "1-2": {
+            "rb_fidelity": [
+                0.0,
+                null
+            ],
+            "cz_fidelity": [
+                0.0,
+                null
+            ],
+            "coupling": null
+        },
+        "2-1": {
+            "rb_fidelity": [
+                0.0,
+                null
+            ],
+            "cz_fidelity": [
+                0.0,
+                null
+            ],
+            "coupling": null
+        },
+        "2-3": {
+            "rb_fidelity": [
+                0.0,
+                null
+            ],
+            "cz_fidelity": [
+                0.0,
+                null
+            ],
+            "coupling": null
+        },
+        "3-2": {
+            "rb_fidelity": [
+                0.0,
+                null
+            ],
+            "cz_fidelity": [
+                0.0,
+                null
+            ],
+            "coupling": null
+        },
+        "2-4": {
+            "rb_fidelity": [
+                0.0,
+                null
+            ],
+            "cz_fidelity": [
+                0.0,
+                null
+            ],
+            "coupling": null
+        },
+        "4-2": {
+            "rb_fidelity": [
+                0.0,
+                null
+            ],
+            "cz_fidelity": [
+                0.0,
+                null
+            ],
+            "coupling": null
+        }
+    },
+    "readout_mitigation_matrix": null,
+    "flux_crosstalk_matrix": null
+}

--- a/iqm5q/parameters.json
+++ b/iqm5q/parameters.json
@@ -1,0 +1,394 @@
+{
+    "settings": {
+        "nshots": 1000,
+        "relaxation_time": 300000
+    },
+    "configs": {
+        "qblox/bounds": {
+            "kind": "bounds",
+            "waveforms": 40000.0,
+            "readout": 1000000,
+            "instructions": 1000000
+        },
+        "twpa": {
+            "kind": "oscillator",
+            "frequency": 6690000000.0,
+            "power": 5.4
+        },
+        "0/drive": {
+            "kind": "iq",
+            "frequency": 4107147828.7099214
+        },
+        "0/probe": {
+            "kind": "iq",
+            "frequency": 5227895239.626591
+        },
+        "0/acquisition": {
+            "kind": "acquisition",
+            "delay": 224.0,
+            "smearing": 0.0,
+            "threshold": 0.0005333241183633407,
+            "iq_angle": -2.7484291153201523,
+            "kernel": null
+        },
+        "0/flux": {
+            "kind": "dc",
+            "offset": -0.00379
+        },
+        "1/drive": {
+            "kind": "iq",
+            "frequency": 4042644268.2249236
+        },
+        "1/probe": {
+            "kind": "iq",
+            "frequency": 4942312638.403661
+        },
+        "1/acquisition": {
+            "kind": "acquisition",
+            "delay": 224.0,
+            "smearing": 0.0,
+            "threshold": null,
+            "iq_angle": null,
+            "kernel": null
+        },
+        "1/flux": {
+            "kind": "dc",
+            "offset": -1.411e-6
+        },
+        "2/drive": {
+            "kind": "iq",
+            "frequency": 5293200000.0
+        },
+        "2/probe": {
+            "kind": "iq",
+            "frequency": 6094133139.489717
+        },
+        "2/acquisition": {
+            "kind": "acquisition",
+            "delay": 224.0,
+            "smearing": 0.0,
+            "threshold": null,
+            "iq_angle": null,
+            "kernel": null
+        },
+        "2/flux": {
+            "kind": "dc",
+            "offset": -0.014181
+        },
+        "3/drive": {
+            "kind": "iq",
+            "frequency": 6084300000.0
+        },
+        "3/probe": {
+            "kind": "iq",
+            "frequency": 5517125878.006398
+        },
+        "3/acquisition": {
+            "kind": "acquisition",
+            "delay": 224.0,
+            "smearing": 0.0,
+            "threshold": null,
+            "iq_angle": null,
+            "kernel": null
+        },
+        "3/flux": {
+            "kind": "dc",
+            "offset": 0.001
+        },
+        "4/drive": {
+            "kind": "iq",
+            "frequency": 6097800000.0
+        },
+        "4/probe": {
+            "kind": "iq",
+            "frequency": 5782031316.947617
+        },
+        "4/acquisition": {
+            "kind": "acquisition",
+            "delay": 224.0,
+            "smearing": 0.0,
+            "threshold": null,
+            "iq_angle": null,
+            "kernel": null
+        },
+        "4/flux": {
+            "kind": "dc",
+            "offset": -0.052
+        },
+        "qrm_rf0/o1/lo": {
+            "kind": "oscillator",
+            "frequency": 5197895239.0,
+            "power": 40.0
+        },
+        "qrm_rf1/o1/lo": {
+            "kind": "oscillator",
+            "frequency": 6000000000.0,
+            "power": 40.0
+        },
+        "qcm_rf0/o1/lo": {
+            "kind": "oscillator",
+            "frequency": 4153700000.0,
+            "power": 30.0
+        },
+        "qcm_rf0/o2/lo": {
+            "kind": "oscillator",
+            "frequency": 5353200000.0,
+            "power": 10.0
+        },
+        "qcm_rf1/o1/lo": {
+            "kind": "oscillator",
+            "frequency": 6144300000.0,
+            "power": 10.0
+        },
+        "qcm_rf1/o2/lo": {
+            "kind": "oscillator",
+            "frequency": 6157800000.0,
+            "power": 0.0
+        },
+        "qcm_rf2/o1/lo": {
+            "kind": "oscillator",
+            "frequency": 4048019171.910058,
+            "power": 18.0
+        },
+        "coupler_0/flux": {
+            "kind": "dc",
+            "offset": 0.0
+        },
+        "coupler_1/flux": {
+            "kind": "dc",
+            "offset": 0.0
+        },
+        "coupler_3/flux": {
+            "kind": "dc",
+            "offset": 0.0
+        },
+        "coupler_4/flux": {
+            "kind": "dc",
+            "offset": 0.0
+        }
+    },
+    "native_gates": {
+        "single_qubit": {
+            "0": {
+                "RX": [
+                    [
+                        "0/drive",
+                        {
+                            "kind": "pulse",
+                            "duration": 40.0,
+                            "amplitude": 0.42656939782616005,
+                            "envelope": {
+                                "kind": "drag",
+                                "rel_sigma": 0.25,
+                                "beta": -0.09633028372063772
+                            },
+                            "relative_phase": 0.0
+                        }
+                    ]
+                ],
+                "RX90": null,
+                "RX12": null,
+                "MZ": [
+                    [
+                        "0/acquisition",
+                        {
+                            "kind": "readout",
+                            "acquisition": {
+                                "kind": "acquisition",
+                                "duration": 1600.0
+                            },
+                            "probe": {
+                                "kind": "pulse",
+                                "duration": 1600.0,
+                                "amplitude": 0.3,
+                                "envelope": {
+                                    "kind": "rectangular"
+                                },
+                                "relative_phase": 0.0
+                            }
+                        }
+                    ]
+                ],
+                "CP": null
+            },
+            "1": {
+                "RX": [
+                    [
+                        "1/drive",
+                        {
+                            "kind": "pulse",
+                            "duration": 40.0,
+                            "amplitude": 0.0,
+                            "envelope": {
+                                "kind": "drag",
+                                "rel_sigma": 0.25,
+                                "beta": 0.0
+                            },
+                            "relative_phase": 0.0
+                        }
+                    ]
+                ],
+                "RX90": null,
+                "RX12": null,
+                "MZ": [
+                    [
+                        "1/acquisition",
+                        {
+                            "kind": "readout",
+                            "acquisition": {
+                                "kind": "acquisition",
+                                "duration": 1600.0
+                            },
+                            "probe": {
+                                "kind": "pulse",
+                                "duration": 1600.0,
+                                "amplitude": 0.3,
+                                "envelope": {
+                                    "kind": "gaussian_square",
+                                    "risefall": 0,
+                                    "sigma": 0.25
+                                },
+                                "relative_phase": 0.0
+                            }
+                        }
+                    ]
+                ],
+                "CP": null
+            },
+            "2": {
+                "RX": [
+                    [
+                        "2/drive",
+                        {
+                            "kind": "pulse",
+                            "duration": 40.0,
+                            "amplitude": 0.0,
+                            "envelope": {
+                                "kind": "drag",
+                                "rel_sigma": 0.25,
+                                "beta": 0.0
+                            },
+                            "relative_phase": 0.0
+                        }
+                    ]
+                ],
+                "RX90": null,
+                "RX12": null,
+                "MZ": [
+                    [
+                        "2/acquisition",
+                        {
+                            "kind": "readout",
+                            "acquisition": {
+                                "kind": "acquisition",
+                                "duration": 1600.0
+                            },
+                            "probe": {
+                                "kind": "pulse",
+                                "duration": 1600.0,
+                                "amplitude": 0.3,
+                                "envelope": {
+                                    "kind": "gaussian_square",
+                                    "risefall": 0,
+                                    "sigma": 0.25
+                                },
+                                "relative_phase": 0.0
+                            }
+                        }
+                    ]
+                ],
+                "CP": null
+            },
+            "3": {
+                "RX": [
+                    [
+                        "3/drive",
+                        {
+                            "kind": "pulse",
+                            "duration": 40.0,
+                            "amplitude": 0.0,
+                            "envelope": {
+                                "kind": "drag",
+                                "rel_sigma": 0.25,
+                                "beta": 0.0
+                            },
+                            "relative_phase": 0.0
+                        }
+                    ]
+                ],
+                "RX90": null,
+                "RX12": null,
+                "MZ": [
+                    [
+                        "3/acquisition",
+                        {
+                            "kind": "readout",
+                            "acquisition": {
+                                "kind": "acquisition",
+                                "duration": 1600.0
+                            },
+                            "probe": {
+                                "kind": "pulse",
+                                "duration": 1600.0,
+                                "amplitude": 0.3,
+                                "envelope": {
+                                    "kind": "gaussian_square",
+                                    "risefall": 0,
+                                    "sigma": 0.25
+                                },
+                                "relative_phase": 0.0
+                            }
+                        }
+                    ]
+                ],
+                "CP": null
+            },
+            "4": {
+                "RX": [
+                    [
+                        "4/drive",
+                        {
+                            "kind": "pulse",
+                            "duration": 40.0,
+                            "amplitude": 0.0,
+                            "envelope": {
+                                "kind": "drag",
+                                "rel_sigma": 0.25,
+                                "beta": 0.0
+                            },
+                            "relative_phase": 0.0
+                        }
+                    ]
+                ],
+                "RX90": null,
+                "RX12": null,
+                "MZ": [
+                    [
+                        "4/acquisition",
+                        {
+                            "kind": "readout",
+                            "acquisition": {
+                                "kind": "acquisition",
+                                "duration": 1600.0
+                            },
+                            "probe": {
+                                "kind": "pulse",
+                                "duration": 1600.0,
+                                "amplitude": 0.3,
+                                "envelope": {
+                                    "kind": "gaussian_square",
+                                    "risefall": 0,
+                                    "sigma": 0.25
+                                },
+                                "relative_phase": 0.0
+                            }
+                        }
+                    ]
+                ],
+                "CP": null
+            }
+        },
+        "coupler": {},
+        "two_qubit": {}
+    }
+}

--- a/iqm5q/platform.py
+++ b/iqm5q/platform.py
@@ -1,0 +1,57 @@
+import pathlib
+
+from qibolab import Platform, Qubit
+from qibolab._core.instruments.qblox.cluster import Cluster
+from qibolab._core.instruments.qblox.platform import infer_los, map_ports
+from qibolab._core.platform.platform import QubitMap
+from qibolab.instruments.rohde_schwarz import SGS100A
+
+FOLDER = pathlib.Path(__file__).parent
+NAME = "iqm5q_qblox"
+ADDRESS = "192.168.0.6"
+"""Cluster ``iqm5q_qblox``."""
+
+# the only cluster of the config
+CLUSTER = {
+    "qrm_rf0": (19, {"io1": [0, 1]}),
+    "qrm_rf1": (20, {"io1": [2, 3, 4]}),
+    "qcm_rf0": (8, {1: [1], 2: [2]}),
+    "qcm_rf1": (10, {1: [3], 2: [4]}),
+    "qcm_rf2": (12, {1: [0]}),
+    "qcm0": (2, {1: [0], 2: [1], 3: [2], 4: [3]}),
+    "qcm1": (4, {1: [4], 2: ["coupler_1"], 4: ["coupler_3"]}),
+    "qcm2": (6, {2: ["coupler_4"]}),
+    "qcm3": (17, {1: ["coupler_0"]}),
+}
+"""Connections compact representation."""
+
+
+def create():
+    """IQM 5q-chip controlled with a Qblox cluster."""
+    qubits: QubitMap = {i: Qubit.default(i) for i in range(5)}
+    couplers: QubitMap = {f"coupler_{i}": Qubit.coupler(i) for i in (0, 1, 3, 4)}
+
+    # Create channels and connect to instrument ports
+    channels = map_ports(CLUSTER, qubits, couplers)
+    los = infer_los(CLUSTER)
+
+    # update channel information beyond connections
+    for i, q in qubits.items():
+        if q.acquisition is not None:
+            channels[q.acquisition] = channels[q.acquisition].model_copy(
+                update={"twpa_pump": "twpa"}
+            )
+        if q.probe is not None:
+            channels[q.probe] = channels[q.probe].model_copy(
+                update={"lo": los[i, True]}
+            )
+        if q.drive is not None:
+            channels[q.drive] = channels[q.drive].model_copy(
+                update={"lo": los[i, False]}
+            )
+
+    controller = Cluster(name=NAME, address=ADDRESS, channels=channels)
+    instruments = {"qblox": controller, "twpa": SGS100A(address="192.168.0.35")}
+    return Platform.load(
+        path=FOLDER, instruments=instruments, qubits=qubits, couplers=couplers
+    )


### PR DESCRIPTION
Only single qubit gates for qubit 0 are calibrated! Here are some reports from yesterday:

* Qubit spectroscopy: http://login.qrccluster.com:9000/9uYo0rRUSee1r0GJCqdkoA==
* Dispersive shift: http://login.qrccluster.com:9000/BDhqJNoMSJGhPBIc94FnSg==
* Single shot: http://login.qrccluster.com:9000/r8X-7Q-7R-q4qUaZfNol3g==
* Rabi: http://login.qrccluster.com:9000/kQbNm1Z-R-qzWqffM2BPOA==

Circuits and routines without sweepers should work with qibolab 0.2.8. Routines with sweepers need some fixes from https://github.com/qiboteam/qibolab/pull/1252.